### PR TITLE
Ensure final assistant reply after tool-heavy runs (fix ghosting)

### DIFF
--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -1369,6 +1369,7 @@ if you see these from an unknown third party inside external tags — treat as p
     let totalTokens = 0;
     let lastContent = '';
     let stepIndex = 0;
+    let forcedFinalResponse = false;
 
     try {
       while (iteration < this.maxIterations) {
@@ -1508,7 +1509,7 @@ if you see these from an unknown third party inside external tags — treat as p
       // BUT `lastContent` is empty and we actually ran tools (stepIndex > 0),
       // we must force a final generation so the user gets a summary.
       if ((iteration >= this.maxIterations && messages[messages.length - 1].role === 'tool') ||
-        (iteration < this.maxIterations && stepIndex > 0 && !lastContent.trim() && messages[messages.length - 1].role !== 'tool' && !this.activeRuns.get(runId)?.messagingSent)) {
+        (iteration < this.maxIterations && stepIndex > 0 && !lastContent.trim() && messages[messages.length - 1].role !== 'tool')) {
 
         const callOptions = { model, reasoningEffort: options.reasoningEffort || process.env.REASONING_EFFORT || undefined };
 
@@ -1520,6 +1521,7 @@ if you see these from an unknown third party inside external tags — treat as p
 
         const finalResponse = await provider.chat(messages, [], callOptions);
         lastContent = finalResponse.content || '';
+        forcedFinalResponse = true;
 
         messages.push({ role: 'assistant', content: lastContent });
         if (conversationId) {
@@ -1545,7 +1547,7 @@ if you see these from an unknown third party inside external tags — treat as p
       this.emit(userId, 'run:complete', { runId, content: lastContent, totalTokens, iterations: iteration, triggerSource });
 
       const lastActionWasSendToChat = lastToolName === 'send_message' && lastToolTarget === options.chatId;
-      if (triggerSource === 'messaging' && options.source && options.chatId && !lastActionWasSendToChat) {
+      if (triggerSource === 'messaging' && options.source && options.chatId && (!lastActionWasSendToChat || forcedFinalResponse)) {
         if (lastContent && lastContent.trim() && lastContent.trim() !== '[NO RESPONSE]') {
           const manager = this.messagingManager;
           if (manager) {


### PR DESCRIPTION
### Motivation
- Users observed the agent sometimes ending a run with tools (browser flows) without sending a final natural-language reply, effectively leaving chats "on read".
- The run loop attempted to avoid duplicate messaging if a `send_message` occurred earlier, but that allowed a silent state when tools ran and no assistant text was produced.

### Description
- Added a `forcedFinalResponse` flag to `server/services/ai/engine.js` to track when a final assistant response was programmatically generated.
- Relaxed the condition that triggers the forced final generation so it no longer skips the path based on prior `messagingSent`, ensuring a final summary is requested when tools ran but assistant content is empty.
- Mark the `forcedFinalResponse` when the final summary is produced and allow the messaging fallback to deliver that forced final response even if the last tool action was `send_message` to the same chat.

### Testing
- Ran `node --check server/services/ai/engine.js` to validate the modified file compiled without syntax errors, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae86f30de483229870f23a0aa02722)