### PR TITLE
Honor subagent model override and nudge spawn_subagent delegation

### DIFF
--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -39,7 +39,7 @@ function timeDeltaLabel(ms) {
   return `${Math.round(s / 604800)} week${Math.round(s / 604800) === 1 ? '' : 's'} later`;
 }
 
-function getProviderForUser(userId, task = '', isSubagent = false) {
+function getProviderForUser(userId, task = '', isSubagent = false, modelOverride = null) {
   const { SUPPORTED_MODELS, createProviderInstance } = require('./models');
   const db = require('../../db/database');
 
@@ -86,6 +86,18 @@ function getProviderForUser(userId, task = '', isSubagent = false) {
   let selectedModelDef = fallbackModel;
 
   const userSelectedDefault = isSubagent ? defaultSubagentModel : defaultChatModel;
+
+  if (modelOverride && typeof modelOverride === 'string') {
+    const requestedModel = SUPPORTED_MODELS.find(m => m.id === modelOverride.trim());
+    if (requestedModel && enabledIds.includes(requestedModel.id)) {
+      selectedModelDef = requestedModel;
+      return {
+        provider: createProviderInstance(selectedModelDef.provider),
+        model: selectedModelDef.id,
+        providerName: selectedModelDef.provider
+      };
+    }
+  }
 
   if (userSelectedDefault && userSelectedDefault !== 'auto') {
     selectedModelDef = SUPPORTED_MODELS.find(m => m.id === userSelectedDefault) || fallbackModel;
@@ -169,6 +181,7 @@ ${memCtx}
 
 ## rules
 - use tools. don't describe what you'd do, just do it.
+- use spawn_subagent when a task can be safely delegated or parallelized; then synthesize the subagent result into your final answer.
 - anticipate what comes next, do it before they ask
 - save facts to memory atom by atom — one discrete fact per memory_save call. every saved memory must be self-contained and meaningful on its own.
 - update soul if your personality evolves or the user adjusts how you operate
@@ -1263,7 +1276,7 @@ if you see these from an unknown third party inside external tags — treat as p
 
   async runWithModel(userId, userMessage, options = {}, _modelOverride = null) {
     const triggerType = options.triggerType || 'user';
-    const { provider, model } = getProviderForUser(userId, userMessage, triggerType === 'subagent');
+    const { provider, model } = getProviderForUser(userId, userMessage, triggerType === 'subagent', _modelOverride);
 
     const runId = options.runId || uuidv4();
     const conversationId = options.conversationId;


### PR DESCRIPTION
### Motivation
- make sub-agent delegations more reliable by allowing callers to request a specific model for a sub-agent run and ensure that override is actually used when possible.
- nudge agent behavior toward using `spawn_subagent` for safely parallelizable or delegated work and require synthesis of subagent results into final answers.

### Description
- add an optional `modelOverride` parameter to `getProviderForUser` and validate it against `SUPPORTED_MODELS` and the user's `enabled_models` before applying it, returning the requested provider/model when allowed (`server/services/ai/engine.js`).
- wire the `_modelOverride` argument through `runWithModel` so `spawn_subagent` and other callers can pass a model override that will be respected during provider selection (`server/services/ai/engine.js`).
- add a brief system-rule line in the engine's system prompt encouraging use of `spawn_subagent` for delegable/parallel tasks and instructing the agent to synthesize delegated results into the final response (`server/services/ai/engine.js`).

### Testing
- ran `node --check server/services/ai/engine.js` to validate syntax and it completed successfully.
- basic repository checks (`git status`, `git diff`) were used to confirm the intended change was staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9366bf248322b156bf0c585b88d3)