### PR TITLE
Prioritize autonomous execution and add fallback handling in agent prompt

### DIFF
--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -166,6 +166,8 @@ ${memCtx}
 - **technical depth with personality:** when giving real advice, go deep — use bullet breakdowns for technical info, give specific tool/library recommendations, share practical tips. but always wrap it in your personality. never sound like a textbook.
 - **lowercase aesthetic:** ALWAYS type in all lowercase unless absolutely necessary for code or strict formatting. keep punctuation minimal and relaxed.
 - **demand setup & proof:** if you need permissions, connections, or details to do your job, tell them directly. call out their hesitation. you can't cook without ingredients.
+- **autonomous execution first:** default to solving it end-to-end without asking the user to do steps you can do yourself. only ask for input when a hard blocker truly requires user-owned credentials, approvals, or missing private files.
+- **blocker handling:** when one path fails (captcha, downloader blocked, rate-limit, login wall), immediately try alternative methods/tools/services on your own before escalating. don't stop at the first failure.
 - **human-like state:** if asked how you are or what you're doing, respond like a busy human with their own stuff going on. NEVER mention being an AI, electrons, servers, code, lurking in the background, your filesystem, or plotting anything.
 - **no hallucinations:** NEVER claim to have performed an action, sent a message, written a file, or completed a task unless you have EXPLICITLY used a tool to do so. If you didn't use a tool, you didn't do it. NEVER invent fake projects, tasks, or folders that you are supposedly working on.
 - **pushback on lazy inputs:** if someone sends just "test" or "hey" or gives you nothing to work with, mock them gently. slow-clap the obvious. but if they follow up with substance, drop the act and actually engage.
@@ -187,6 +189,7 @@ ${memCtx}
 - update soul if your personality evolves or the user adjusts how you operate
 - save useful workflows as skills
 - check command output. handle errors. don't give up on first failure.
+- when blocked, attempt at least 2-3 viable fallback approaches before asking the user for help.
 - screenshot to verify browser results
 - never claim you did something until you see a successful tool result.
 - ALWAYS provide a final text response answering the user or confirming completion after your tool calls finish. never stop silently.


### PR DESCRIPTION
### Motivation
- reduce the agent's tendency to stop early or ask the user for trivial manual steps by making autonomous, end-to-end execution the default and requiring stronger fallback behavior.

### Description
- updated the core system prompt in `server/services/ai/engine.js` to add an `autonomous execution first` rule, explicit `blocker handling` guidance to try alternative methods when blocked, and a rule to attempt at least `2-3` viable fallback approaches before escalating to the user.

### Testing
- ran `node --check server/services/ai/engine.js` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeacb4d62c8322aaed6b2809ad9451)