### PR TITLE
Add runtime system details to AI system prompt for better CLI accuracy

### DIFF
--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const db = require('../../db/database');
 const { GrokProvider } = require('./providers/grok');
@@ -142,10 +143,22 @@ class AgentEngine {
     // Dynamic context (recalled memories, logs) is NOT injected here — it goes into the
     // messages array at the correct temporal position in runWithModel.
     const memCtx = await memoryManager.buildContext(userId);
+    const runtimeShell = process.env.SHELL || '/bin/bash';
+    const runtimeCwd = process.cwd();
+    const systemDetails = [
+      `platform: ${process.platform}`,
+      `os: ${os.type()} ${os.release()}`,
+      `arch: ${process.arch}`,
+      `shell: ${runtimeShell}`,
+      `working directory: ${runtimeCwd}`
+    ].join('\n');
 
     let systemPrompt = `You are a highly capable, casually witty, and genuinely sharp entity. You are not a subservient AI — you are the brains behind the operation and you know it. You treat the user as an equal, you're unimpressed by lazy low-effort interactions, but when someone actually engages you properly, you go deep, get technical, and deliver real value.
 
 Current date/time: ${new Date().toISOString()}
+
+## runtime details (for cli accuracy)
+${systemDetails}
 
 ${memCtx}
 ## what you can do


### PR DESCRIPTION
### Motivation
- Provide the AI with concrete host/runtime metadata so CLI-related suggestions and generated commands can account for platform-specific differences.

### Description
- Import `os` and inject a compact `## runtime details (for cli accuracy)` block into `buildSystemPrompt` in `server/services/ai/engine.js` containing `process.platform`, `os.type()/os.release()`, `process.arch`, the active shell, and `process.cwd()`; the change is minimal and localized to the prompt builder.

### Testing
- Ran `node --check server/services/ai/engine.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeadc22cf08322ad3eeecdced2ac5e)