### PR TITLE
feat(health): add metric_type alias normalization and canonical mapping

### DIFF
--- a/server/services/ai/tools.js
+++ b/server/services/ai/tools.js
@@ -588,7 +588,7 @@ function getAvailableTools(app, options = {}) {
             parameters: {
                 type: 'object',
                 properties: {
-                    metric_type: { type: 'string', description: 'Metric to query: "steps", "heart_rate", "sleep_session", "exercise_session", "weight". Omit to see what is available.' },
+                    metric_type: { type: 'string', description: 'Metric to query. Canonical values: "steps" (also accepts: "step", "step_count"), "heart_rate" (also accepts: "heartbeat", "heartrate", "pulse", "bpm"), "sleep_session" (also accepts: "sleep"), "exercise_session" (also accepts: "exercise", "workout", "activity"), "weight" (also accepts: "body_weight"). Omit to see what is available.' },
                     limit: { type: 'number', description: 'Max recent records to return (default 10, max 200). Use a small number unless the user explicitly asks for a full history.' }
                 }
             }

--- a/server/services/health/ingestion.js
+++ b/server/services/health/ingestion.js
@@ -169,13 +169,41 @@ function getHealthSyncStatus(userId) {
   };
 }
 
+// Aliases map collapsed/synonym forms → canonical stored metric_type values.
+// Applied after camelCase/space normalization, so keys here are already lowercase+underscored.
+const METRIC_TYPE_ALIASES = {
+  // heart rate variants
+  heartbeat: 'heart_rate',
+  heartrate: 'heart_rate',
+  heart_beat: 'heart_rate',
+  bpm: 'heart_rate',
+  pulse: 'heart_rate',
+  // sleep variants
+  sleep: 'sleep_session',
+  sleeping: 'sleep_session',
+  // exercise variants
+  exercise: 'exercise_session',
+  workout: 'exercise_session',
+  activity: 'exercise_session',
+  // weight variants
+  body_weight: 'weight',
+  bodyweight: 'weight',
+  mass: 'weight',
+  // steps variants
+  step_count: 'steps',
+  stepcount: 'steps',
+  step: 'steps',
+};
+
 function normalizeMetricType(raw) {
   // Accept any casing/spacing: "HeartRate" → "heart_rate", "Steps" → "steps", etc.
-  return String(raw || '')
+  const normalized = String(raw || '')
     .trim()
     .replace(/([a-z])([A-Z])/g, '$1_$2')  // camelCase/PascalCase → snake_case
     .replace(/[\s-]+/g, '_')               // spaces/dashes → underscore
     .toLowerCase();
+  // Resolve known synonyms to canonical stored values
+  return METRIC_TYPE_ALIASES[normalized] || normalized;
 }
 
 function readHealthData(userId, metricType, limit = 50) {


### PR DESCRIPTION
Introduce METRIC_TYPE_ALIASES and normalizeMetricType to map synonyms to canonical metric_type values after normalization. This improves ingestion consistency for health data. Update tools description to document supported synonyms.