### PR TITLE
Add systemd fallback and npm dependency installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,11 @@ else
 fi
 
 echo
-info "Running Node manager installer..."
+info "Installing Node.js dependencies..."
 cd "$INSTALL_DIR"
+npm install --omit=dev --no-audit --no-fund
+ok "Dependencies ready"
+
+echo
+info "Running Node manager installer..."
 exec node ./bin/neoagent.js install

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -1593,7 +1593,12 @@ async function cmdInstall() {
   if (platform === 'macos' && commandExists('launchctl')) {
     installMacService();
   } else if (platform === 'linux' && commandExists('systemctl')) {
-    installLinuxService();
+    try {
+      installLinuxService();
+    } catch (err) {
+      logWarn(`systemd setup failed (${err.message}); falling back to detached process`);
+      startFallback();
+    }
   } else {
     startFallback();
   }
@@ -1730,7 +1735,12 @@ async function cmdFix() {
   if (platform === 'macos' && commandExists('launchctl')) {
     installMacService();
   } else if (platform === 'linux' && commandExists('systemctl')) {
-    installLinuxService();
+    try {
+      installLinuxService();
+    } catch (err) {
+      logWarn(`systemd setup failed (${err.message}); falling back to detached process`);
+      startFallback();
+    }
   } else {
     startFallback();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "supertest": "^7.2.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@algolia/abtesting": {


### PR DESCRIPTION
## Problem

The installation process has two issues:
1. If systemd service installation fails on Linux, the entire install command fails instead of gracefully falling back to a detached process
2. Node.js dependencies are not installed before running the manager installer, which could cause runtime failures

## Changes

**lib/manager.js:**
- Added try-catch error handling around `installLinuxService()` calls in both `cmdInstall()` and `cmdFix()` functions
- When systemd setup fails, logs a warning and falls back to `startFallback()` instead of propagating the error
- This ensures the installation completes even if systemd configuration encounters issues

**install.sh:**
- Added explicit `npm install --omit=dev --no-audit --no-fund` step before running the Node manager installer
- Reordered output messages to reflect the actual sequence of operations
- Ensures all dependencies are available before the manager installer executes

## Verification

- Verify `npm install` completes successfully during installation
- Test systemd installation failure scenarios on Linux to confirm fallback to detached process works
- Confirm warning message is logged when systemd setup fails
- Verify installation completes successfully on systems with and without systemd

## Checklist

- [ ] This pull request targets the `beta` branch, not `main`.
- [ ] I followed `GUIDELINES.md`.
- [ ] I added or updated focused tests for changed behavior.
- [ ] I updated documentation for user-visible commands, settings, APIs, or workflows.
- [ ] I did not add credentials, personal data, runtime data, or generated secrets.
- [ ] I called out migrations, security implications, and platform-specific behavior above.

https://claude.ai/code/session_01AwDfvVaP5Sygwhyu6XYGmK