### PR TITLE
v2.5.2: Hermes loop hardening — prod reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,30 +42,12 @@ service to a network.
 
 ## ✨ What makes it different
 
-**It is a service, not just a chat window.** NeoAgent keeps tasks, integrations,
-memory, connected devices, and messaging channels available between sessions.
-
-**Memory is stored as structured local data.** Durable facts are separated from
-conversation history, scoped by user and agent, and updated when newer
-information replaces older information. NeoAgent can also index supported
-integration content with source references. See [How memory works](docs/memory.md).
-
-**It operates real devices.** The agent can use an isolated browser and shell,
-control an Android device or emulator over ADB, or work through a paired Chrome
-extension and desktop companion.
-
-**Automation can start without a message.** Tasks can run on a schedule or from
-supported Gmail, Outlook, Slack, Teams, personal WhatsApp, and weather events.
-Android notifications can also start an agent run.
-
-**Agents and users have separate state.** Specialist agents can have their own
-memory, settings, tools, account assignments, conversations, and task history.
-Multi-user deployments include administrative account controls and optional
-email confirmation.
-
-**The same server has several interfaces.** NeoAgent includes web, Android,
-desktop, and Android launcher clients, messaging bridges, a Chrome extension,
-and firmware for a supported ESP32-S3 wearable.
+- **It is a service, not just a chat window.** NeoAgent keeps tasks, integrations, memory, connected devices, and messaging channels available between sessions.
+- **Memory is stored as structured local data.** Durable facts are separated from conversation history, scoped by user and agent, and updated when newer information replaces older information. NeoAgent can also index supported integration content with source references. See [How memory works](docs/memory.md).
+- **It operates real devices.** The agent can use an isolated browser and shell, control an Android device or emulator over ADB, or work through a paired Chrome extension and desktop companion.
+- **Automation can start without a message.** Tasks can run on a schedule or from supported Gmail, Outlook, Slack, Teams, personal WhatsApp, and weather events. Android notifications can also start an agent run.
+- **Agents and users have separate state.** Specialist agents can have their own memory, settings, tools, account assignments, conversations, and task history. Multi-user deployments include administrative account controls and optional email confirmation.
+- **The same server has several interfaces.** NeoAgent includes web, Android, desktop, and Android launcher clients, messaging bridges, a Chrome extension, and firmware for a supported ESP32-S3 wearable.
 
 ## 🖥️ Interfaces
 

--- a/flutter_app/lib/main_chat.dart
+++ b/flutter_app/lib/main_chat.dart
@@ -335,10 +335,7 @@ class _ChatPanelState extends State<ChatPanel> with WidgetsBindingObserver {
       last?.role,
       last?.content.length,
       last?.typing,
-      controller.toolEvents.length,
       activeRun?.runId,
-      activeRun?.phase,
-      activeRun?.iteration,
       controller.streamingAssistant.length,
       controller.isSendingMessage,
     ].join('|');

--- a/flutter_app/lib/main_operations.dart
+++ b/flutter_app/lib/main_operations.dart
@@ -4946,6 +4946,13 @@ const List<_TaskTriggerOption> _taskTriggerOptions = <_TaskTriggerOption>[
     providerKey: 'whatsapp_personal',
     appKey: 'personal',
   ),
+  _TaskTriggerOption(
+    type: 'android_notification_received',
+    section: 'System',
+    label: 'Android Notification Received',
+    description: 'Run when a notification arrives on your device.',
+    icon: Icons.notifications_active_rounded,
+  ),
 ];
 
 _TaskTriggerOption _taskTriggerOptionForType(String type) {

--- a/flutter_app/lib/main_shared.dart
+++ b/flutter_app/lib/main_shared.dart
@@ -689,6 +689,8 @@ Color _runPhaseColor(String phase) {
 class _RunStatusPanel extends StatelessWidget {
   const _RunStatusPanel({required this.run, required this.tools});
 
+  static const double _timelineViewportHeight = 188;
+
   final ActiveRunState? run;
   final List<ToolEventItem> tools;
 
@@ -712,7 +714,8 @@ class _RunStatusPanel extends StatelessWidget {
                 if (phase.isNotEmpty) ...<Widget>[
                   _PulseHalo(
                     color: phaseColor,
-                    animate: phase.toLowerCase() != 'completed' &&
+                    animate:
+                        phase.toLowerCase() != 'completed' &&
                         phase.toLowerCase() != 'stopped',
                     child: Container(
                       width: 30,
@@ -802,14 +805,17 @@ class _RunStatusPanel extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 14),
-              ...tools.asMap().entries.map(
-                (entry) => Padding(
-                  padding: EdgeInsets.only(
-                    bottom: entry.key == tools.length - 1 ? 0 : 12,
-                  ),
-                  child: _ToolEventTimelineRow(
-                    tool: entry.value,
-                    isLast: entry.key == tools.length - 1,
+              SizedBox(
+                height: _timelineViewportHeight,
+                child: ListView.separated(
+                  primary: false,
+                  padding: EdgeInsets.zero,
+                  physics: const ClampingScrollPhysics(),
+                  itemCount: tools.length,
+                  separatorBuilder: (context, _) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) => _ToolEventTimelineRow(
+                    tool: tools[index],
+                    isLast: index == tools.length - 1,
                   ),
                 ),
               ),
@@ -3697,27 +3703,32 @@ class _QuickReplyBar extends StatelessWidget {
     return Wrap(
       spacing: 8,
       runSpacing: 8,
-      children: payload.options.map((option) {
-        return GestureDetector(
-          onTap: () => onSelected(option.value),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-            decoration: BoxDecoration(
-              color: _accentMuted,
-              borderRadius: BorderRadius.circular(999),
-              border: Border.all(color: _accent.withValues(alpha: 0.4)),
-            ),
-            child: Text(
-              option.label,
-              style: TextStyle(
-                fontSize: 13,
-                color: _accent,
-                fontWeight: FontWeight.w600,
+      children: payload.options
+          .map((option) {
+            return GestureDetector(
+              onTap: () => onSelected(option.value),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: _accentMuted,
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: _accent.withValues(alpha: 0.4)),
+                ),
+                child: Text(
+                  option.label,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: _accent,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
               ),
-            ),
-          ),
-        );
-      }).toList(growable: false),
+            );
+          })
+          .toList(growable: false),
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.4",
+  "version": "2.5.2-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.5.2-beta.4",
+      "version": "2.5.2-beta.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.1",
+  "version": "2.5.2-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.5.2-beta.1",
+      "version": "2.5.2-beta.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.4.4-beta.12",
+  "version": "2.5.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.4.4-beta.12",
+      "version": "2.5.2-beta.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.2",
+  "version": "2.5.2-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.5.2-beta.2",
+      "version": "2.5.2-beta.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.3",
+  "version": "2.5.2-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.5.2-beta.3",
+      "version": "2.5.2-beta.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.0",
+  "version": "2.5.2-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.5.2-beta.0",
+      "version": "2.5.2-beta.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.5",
+  "version": "2.5.2-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neoagent",
-      "version": "2.5.2-beta.5",
+      "version": "2.5.2-beta.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.0",
+  "version": "2.5.2-beta.1",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.4.4-beta.12",
+  "version": "2.5.2-beta.0",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.3",
+  "version": "2.5.2-beta.4",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.5",
+  "version": "2.5.2-beta.6",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.2",
+  "version": "2.5.2-beta.3",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.1",
+  "version": "2.5.2-beta.2",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoagent",
-  "version": "2.5.2-beta.4",
+  "version": "2.5.2-beta.5",
   "description": "Proactive personal AI agent with no limits",
   "license": "AGPL-3.0-only",
   "main": "server/index.js",

--- a/server/routes/triggers.js
+++ b/server/routes/triggers.js
@@ -67,24 +67,42 @@ router.post('/notification', async (req, res) => {
   }
 
   // Fire-and-forget after response is sent — errors here must never touch res.
-  Promise.resolve().then(() => {
-    const agentEngine = req.app.locals.agentEngine;
-    if (!agentEngine) return;
-    const defaultAgentId = db.prepare('SELECT id FROM agents WHERE user_id = ? ORDER BY is_default DESC LIMIT 1').get(req.session.userId)?.id;
-    if (!defaultAgentId) return;
-    const prompt = [
-      `A notification arrived on your device.`,
-      `App: ${app_package || 'unknown'}`,
-      title ? `Title: ${title}` : '',
-      body ? `Body: ${body}` : '',
-      `Evaluate whether this notification requires action or a reply. If it is routine or low-priority, do nothing.`,
-    ].filter(Boolean).join('\n');
-    return agentEngine.run(req.session.userId, prompt, {
-      agentId: defaultAgentId,
-      triggerSource: 'tasks',
-      context: { source: 'notification', app_package, title, body, action_taken },
-    });
-  }).catch(err => console.error('[Triggers] Notification agent run failed:', err.message));
+  Promise.resolve().then(async () => {
+    const taskRuntime = req.app.locals.taskRuntime;
+    if (!taskRuntime) return;
+    
+    const tasks = taskRuntime.taskRepository.listEnabledByTriggerTypes(['android_notification_received']) || [];
+    for (const task of tasks) {
+      if (task.user_id !== req.session.userId) continue;
+      
+      let config = {};
+      try {
+        config = JSON.parse(task.trigger_config || '{}');
+      } catch (e) {}
+      
+      if (config.appPackage && config.appPackage.trim() && config.appPackage.trim() !== app_package) {
+        continue;
+      }
+      
+      const payload = {
+        fingerprint: `notification:${Date.now()}:${Math.random().toString(36).substr(2, 5)}`,
+        timestamp: new Date().toISOString(),
+        context: {
+          triggerEvent: {
+            provider: 'android_notification',
+            appPackage: app_package,
+            title: title,
+            body: body,
+            actionTaken: action_taken
+          }
+        }
+      };
+      
+      await taskRuntime.fireTaskFromTrigger(task.id, task.user_id, payload).catch(err => {
+        console.error('[Triggers] Notification task trigger failed:', err.message);
+      });
+    }
+  }).catch(err => console.error('[Triggers] Notification background processing failed:', err.message));
 });
 
 module.exports = router;

--- a/server/services/ai/deliverables/artifact_helpers.js
+++ b/server/services/ai/deliverables/artifact_helpers.js
@@ -123,6 +123,7 @@ async function buildArtifactFromCandidate(candidate, fallbackKind = 'artifact') 
       artifact.size = (await fs.promises.stat(artifact.path)).size;
     } catch (error) {
       console.warn('[deliverables] Failed to stat artifact candidate:', artifact.path, error?.message || error);
+      return null;
     }
   }
   return artifact.path || artifact.uri ? artifact : null;

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -117,6 +117,7 @@ const MESSAGING_PROGRESS_REPEAT_MS = 90 * 1000;
 const MESSAGING_PROGRESS_STALL_MS = 240 * 1000;
 const MESSAGING_PROGRESS_TICK_MS = 15 * 1000;
 const GOAL_CONTRACT_SUCCESS_CRITERIA_LIMIT = 12;
+const MODEL_CALL_TIMEOUT_MS = 5 * 60 * 1000;
 
 function isoNow() {
   return new Date().toISOString();
@@ -134,6 +135,31 @@ function formatElapsedDuration(durationMs) {
   const seconds = totalSeconds % 60;
   if (seconds === 0) return `${minutes}m`;
   return `${minutes}m ${seconds}s`;
+}
+
+function resolveModelCallTimeoutMs(options = {}) {
+  const requested = Number(options?.modelCallTimeoutMs);
+  if (Number.isFinite(requested) && requested > 0) {
+    return Math.max(10, requested);
+  }
+  return MODEL_CALL_TIMEOUT_MS;
+}
+
+async function withModelCallTimeout(promise, options = {}, label = 'Model call') {
+  const timeoutMs = resolveModelCallTimeoutMs(options);
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new Error(`${label} timed out after ${formatElapsedDuration(timeoutMs)}.`);
+      error.code = 'MODEL_CALL_TIMEOUT';
+      reject(error);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([Promise.resolve(promise), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function cloneInterimHistory(history = []) {
@@ -185,6 +211,23 @@ function hasVisibleInterimActivity(runMeta) {
     || (Array.isArray(runMeta?.interimMessages) && runMeta.interimMessages.length > 0)
     || Number(runMeta?.progressLedger?.heartbeatCount || 0) > 0
   );
+}
+
+function requireSuccessfulMessagingDelivery(result, label = 'Messaging delivery') {
+  if (result?.success === true && result?.suppressed !== true) {
+    return result;
+  }
+  const reason = String(
+    result?.error
+    || result?.reason
+    || result?.result?.error
+    || result?.result?.reason
+    || 'the platform did not confirm delivery',
+  ).trim();
+  const error = new Error(`${label} failed: ${reason}`);
+  error.code = 'MESSAGING_DELIVERY_FAILED';
+  error.deliveryResult = result || null;
+  throw error;
 }
 
 function normalizeGoalCriteria(value) {
@@ -257,7 +300,7 @@ function mergeGoalContracts(existing = null, patch = null) {
   const nextPatch = normalizeGoalContract(patch) || null;
   if (!current && !nextPatch) return null;
 
-  const goal = String(nextPatch?.goal || current?.goal || '').trim();
+  const goal = String(current?.goal || nextPatch?.goal || '').trim();
   const successCriteria = normalizeGoalCriteria([
     ...(current?.successCriteria || []),
     ...(nextPatch?.successCriteria || []),
@@ -363,7 +406,6 @@ function resolveRunGoalContext(runMeta, analysis = null, plan = null) {
 }
 
 function buildCompletionDecisionPrompt({
-  mode,
   triggerSource,
   messagingSent = false,
   goalContext,
@@ -373,51 +415,27 @@ function buildCompletionDecisionPrompt({
   lastReply,
   iteration,
   maxIterations,
-  progressSummary = '',
-  platform = null,
 }) {
-  const draftReply = mode === 'messaging'
-    ? (normalizeOutgoingMessage(lastReply || '', platform, { collapseWhitespace: false })
-      ? String(lastReply || '').trim()
-      : '')
-    : normalizeOutgoingMessage(lastReply) || '';
+  const draftReply = normalizeOutgoingMessage(lastReply) || '';
   const lines = [
     'Return JSON only.',
+    'Decide whether this run should continue autonomously or stop now.',
+    'Schema: {"status":"continue|complete|blocked","reason":"short concrete reason"}',
+    'Rules:',
+    '- Use "continue" whenever any safe next step remains in this same run.',
+    '- Use "complete" only when the requested outcome is actually achieved and the latest draft is the finished user-facing answer.',
+    '- Use "blocked" only when a specific external dependency, missing user input, or permission outside this run is required and the latest draft is the blocker reply.',
+    '- If the latest draft asks the user for a missing required value, confirmation, or choice needed to proceed, use "blocked" so the run waits instead of repeating the same ask.',
+    '- A progress note, next-step note, apology, plan, or promise to investigate is "continue", not "complete".',
+    '- A single failed tool attempt is not blocked if another safe retry, verification step, or alternative path remains.',
+    '- A tool-specific API error, timeout, rate limit, or missing result inside this run is usually "continue", not "blocked", if any other available tool could still make progress.',
+    `- If completion_confidence_required is ${goalContext.effectiveCompletionConfidence} and the latest draft depends on unverified assumptions, use "continue" so the run can gather evidence, inspect state, or narrow the reply.`,
+    triggerSource === 'messaging' && messagingSent
+      ? '- A final reply was already delivered via send_message. Use "complete" unless concrete task work remains.'
+      : triggerSource === 'messaging'
+        ? '- For messaging, do not stop on a partial status message. Continue unless the task is actually complete or externally blocked.'
+        : '- Do not stop just because you wrote a status update. Continue unless the task is actually complete or externally blocked.',
   ];
-
-  if (mode === 'messaging') {
-    lines.push(
-      'A messaging run is about to stop after sending user-visible progress, but no final delivery has happened yet.',
-      'Decide whether the run should keep working, finish with the completed result now, or stop with one blocker reply now.',
-      'Schema: {"status":"continue|complete|blocked","reason":"short concrete reason","final_reply":"string"}',
-      'Rules:',
-      '- Use "continue" whenever any safe next step remains in this same run.',
-      '- Use "complete" only when the requested outcome is actually achieved and final_reply is the finished user-facing answer to send now.',
-      '- Use "blocked" only when a specific external dependency, missing user input, or permission outside this run is required and final_reply is the concise blocker reply to send now.',
-      '- A progress note, next-step note, apology, plan, or "I will investigate" draft is "continue", not "complete" and not "blocked".',
-      '- If user-visible progress was already sent and no final delivery exists yet, do not stop silently and do not stop on a status-only draft.',
-      '- final_reply must be empty when status is "continue".',
-    );
-  } else {
-    lines.push(
-      'Decide whether this run should continue autonomously or stop now.',
-      'Schema: {"status":"continue|complete|blocked","reason":"short concrete reason"}',
-      'Rules:',
-      '- Use "continue" whenever any safe next step remains in this same run.',
-      '- Use "complete" only when the requested outcome is actually achieved or a truthful final user reply is already ready now.',
-      '- Use "blocked" only when a specific external dependency outside this run is required.',
-      '- If the latest draft asks the user for a missing required value, confirmation, or choice needed to proceed, use "blocked" so the run waits instead of repeating the same ask.',
-      '- A progress update is not complete.',
-      '- A single failed tool attempt is not blocked if another safe retry, verification step, or alternative path remains.',
-      '- A tool-specific API error, timeout, rate limit, or missing result inside this run is usually "continue", not "blocked", if any other available tool could still make progress.',
-      `- If completion_confidence_required is ${goalContext.effectiveCompletionConfidence} and the latest draft depends on unverified assumptions, use "continue" so the run can gather evidence, inspect state, or narrow the reply.`,
-      triggerSource === 'messaging' && messagingSent
-        ? '- A reply was already delivered to the user via send_message. Use "complete" unless there is concrete remaining work (e.g., a tool call you still need to make) before the task is truly done. Do not send follow-up elaborations or re-introductions.'
-        : triggerSource === 'messaging'
-          ? '- For messaging, do not stop on a partial status message. Continue unless the task is actually complete or externally blocked. If you already asked for missing user input, choose "blocked" and wait.'
-          : '- Do not stop just because you wrote a status update. Continue unless the task is actually complete or externally blocked.',
-    );
-  }
 
   lines.push(
     goalContext.effectiveGoal ? `Goal: ${goalContext.effectiveGoal}` : '',
@@ -428,59 +446,19 @@ function buildCompletionDecisionPrompt({
       : '',
     `Current iteration: ${iteration} of ${maxIterations}.`,
     `Available tools in this run: ${summarizeAvailableTools(tools) || 'none'}`,
-    mode === 'messaging' && progressSummary ? `Progress ledger: ${progressSummary}` : '',
     `Recent tool evidence:\n${summarizeToolExecutions(toolExecutions, 8) || 'none'}`,
     `Latest draft reply:\n${draftReply || '(empty)'}`,
-    mode === 'messaging' ? buildPlatformFormattingGuide(platform) : '',
   );
   return lines.filter(Boolean).join('\n');
 }
 
-function normalizeCompletionDecision(raw, {
-  mode,
-  fallbackStatus = 'continue',
-  platform = null,
-  draftReply = '',
-}) {
+function normalizeCompletionDecision(raw, fallbackStatus = 'continue') {
   const allowed = new Set(['continue', 'complete', 'blocked']);
-  if (mode === 'messaging') {
-    let status = allowed.has(String(raw.status || '').trim().toLowerCase())
-      ? String(raw.status || '').trim().toLowerCase()
-      : 'continue';
-    let finalReply = normalizeOutgoingMessage(raw.final_reply || '', platform, {
-      collapseWhitespace: false,
-    })
-      ? String(raw.final_reply || '').trim()
-      : '';
-    if (status === 'continue') {
-      finalReply = '';
-    } else if (!finalReply && draftReply) {
-      finalReply = draftReply;
-    } else if (!finalReply) {
-      status = 'continue';
-    }
-    return {
-      status,
-      reason: String(raw.reason || '').trim().slice(0, 400),
-      final_reply: finalReply,
-    };
-  }
-
   const requestedStatus = String(raw.status || '').trim().toLowerCase();
   return {
     status: allowed.has(requestedStatus) ? requestedStatus : fallbackStatus,
     reason: String(raw.reason || '').trim().slice(0, 400),
   };
-}
-
-function shouldRequireMessagingFinalityCheck(runMeta) {
-  return Boolean(
-    runMeta
-    && runMeta.triggerSource === 'messaging'
-    && runMeta.finalDeliverySent !== true
-    && !runMeta.terminalInterim
-    && hasVisibleInterimActivity(runMeta)
-  );
 }
 
 function planningDepthForForceMode(forceMode) {
@@ -706,6 +684,7 @@ class AgentEngine {
     this.taskRuntime = services.taskRuntime || null;
     this.memoryManager = services.memoryManager || null;
     this.voiceRuntimeManager = services.voiceRuntimeManager || null;
+    this.messagingDeliveryRetry = services.messagingDeliveryRetry || {};
   }
 
   async buildSystemPrompt(userId, context = {}) {
@@ -926,21 +905,6 @@ class AgentEngine {
       .run(JSON.stringify(next), runId);
   }
 
-  replaceLatestConversationAssistantMessage(conversationId, content) {
-    if (!conversationId) return false;
-    const messageId = db.prepare(
-      `SELECT id
-       FROM conversation_messages
-       WHERE conversation_id = ? AND role = 'assistant'
-       ORDER BY id DESC
-       LIMIT 1`
-    ).get(conversationId)?.id;
-    if (!messageId) return false;
-    db.prepare('UPDATE conversation_messages SET content = ? WHERE id = ?')
-      .run(content, messageId);
-    return true;
-  }
-
   updateRunGoalContract(runId, patch = {}, options = {}) {
     const runMeta = this.getRunMeta(runId);
     if (!runMeta) return null;
@@ -1031,6 +995,7 @@ class AgentEngine {
   markRunFinalDelivery(runId, content = '', timestamp = isoNow()) {
     const runMeta = this.getRunMeta(runId);
     if (!runMeta) return null;
+    runMeta.messagingSent = true;
     runMeta.finalDeliverySent = true;
     runMeta.lastSentMessage = String(content || '').trim() || runMeta.lastSentMessage || '';
     const ledger = this.updateRunProgress(runId, {
@@ -1142,13 +1107,14 @@ class AgentEngine {
       if (!platform || !chatId || !this.messagingManager) {
         return { sent: false, skipped: true, reason: 'Messaging context is not available.' };
       }
-      await this.messagingManager.sendMessage(userId, platform, chatId, normalizedContent, {
+      const deliveryResult = await this.messagingManager.sendMessage(userId, platform, chatId, normalizedContent, {
         agentId,
         runId,
         persistConversation: true,
         metadata,
         deliveryKind: 'interim',
       });
+      requireSuccessfulMessagingDelivery(deliveryResult, 'Interim messaging delivery');
     } else if (triggerSource === 'voice_live') {
       const voiceSessionId = runMeta.voiceSessionId || null;
       const manager = this.voiceRuntimeManager || this.app?.locals?.voiceRuntimeManager || null;
@@ -1242,42 +1208,72 @@ class AgentEngine {
     phase = 'structured',
   }) {
     const startedAt = Date.now();
-    const response = await withProviderRetry(
-      () => provider.chat(
-        sanitizeConversationMessages([
-          ...messages,
-          { role: 'system', content: prompt },
-        ]),
-        [],
-        {
-          model,
-          maxTokens,
-          reasoningEffort: reasoningEffort || this.getReasoningEffort(providerName, {}),
-        }
-      ),
-      { label: `Engine ${model} (structured)` }
-    );
-    if (telemetry?.runId && telemetry?.userId) {
-      recordModelUsage({
-        runId: telemetry.runId,
-        stepId: telemetry.stepId || null,
-        userId: telemetry.userId,
-        agentId: telemetry.agentId || null,
-        provider: providerName,
-        model,
-        phase,
-        usage: response.usage,
-        latencyMs: Date.now() - startedAt,
+    const structuredStep = `model:${phase}`;
+    if (telemetry?.runId) {
+      this.updateRunProgress(telemetry.runId, {
+        currentPhase: 'model',
+        currentStep: structuredStep,
+        currentTool: null,
+        currentStepStartedAt: isoNow(),
       });
     }
 
-    const parsed = parseJsonObject(response.content || '');
-    const normalizedUsage = normalizeUsage(response.usage);
-    return {
-      value: normalize(parsed || {}, fallback),
-      raw: response.content || '',
-      usage: normalizedUsage?.totalTokens || 0,
-    };
+    let completed = false;
+    try {
+      const response = await withProviderRetry(
+        () => withModelCallTimeout(
+          provider.chat(
+            sanitizeConversationMessages([
+              ...messages,
+              { role: 'system', content: prompt },
+            ]),
+            [],
+            {
+              model,
+              maxTokens,
+              reasoningEffort: reasoningEffort || this.getReasoningEffort(providerName, {}),
+            }
+          ),
+          telemetry || {},
+          `${phase} model call`,
+        ),
+        { label: `Engine ${model} (structured)` }
+      );
+      completed = true;
+      if (telemetry?.runId && telemetry?.userId) {
+        recordModelUsage({
+          runId: telemetry.runId,
+          stepId: telemetry.stepId || null,
+          userId: telemetry.userId,
+          agentId: telemetry.agentId || null,
+          provider: providerName,
+          model,
+          phase,
+          usage: response.usage,
+          latencyMs: Date.now() - startedAt,
+        });
+      }
+
+      const parsed = parseJsonObject(response.content || '');
+      const normalizedUsage = normalizeUsage(response.usage);
+      return {
+        value: normalize(parsed || {}, fallback),
+        raw: response.content || '',
+        usage: normalizedUsage?.totalTokens || 0,
+      };
+    } finally {
+      const runMeta = telemetry?.runId ? this.getRunMeta(telemetry.runId) : null;
+      if (runMeta?.progressLedger?.currentStep === structuredStep) {
+        this.updateRunProgress(telemetry.runId, {
+          currentPhase: 'idle',
+          currentStep: null,
+          currentTool: null,
+          currentStepStartedAt: null,
+        }, {
+          verified: completed,
+        });
+      }
+    }
   }
 
   async requestModelResponse({
@@ -1304,8 +1300,16 @@ class AgentEngine {
       if (options.stream !== false) {
         let emittedContent = false;
         const stream = provider.stream(requestMessages, tools, callOptions);
+        const iterator = stream[Symbol.asyncIterator]();
         try {
-          for await (const chunk of stream) {
+          while (true) {
+            const next = await withModelCallTimeout(
+              iterator.next(),
+              options,
+              `Model stream iteration ${iteration}`,
+            );
+            if (next.done) break;
+            const chunk = next.value;
             if (chunk.type === 'content') {
               emittedContent = true;
               streamContent += chunk.content;
@@ -1329,13 +1333,18 @@ class AgentEngine {
             }
           }
         } catch (err) {
+          Promise.resolve(iterator.return?.()).catch(() => {});
           // Once tokens have streamed to the client a retry would duplicate
           // output, so only the pre-stream window is safe to replay.
           if (emittedContent) err.__providerRetryUnsafe = true;
           throw err;
         }
       } else {
-        response = await provider.chat(requestMessages, tools, callOptions);
+        response = await withModelCallTimeout(
+          provider.chat(requestMessages, tools, callOptions),
+          options,
+          `Model iteration ${iteration}`,
+        );
       }
 
       return { response, streamContent };
@@ -1485,7 +1494,6 @@ class AgentEngine {
       model,
       messages,
       prompt: buildCompletionDecisionPrompt({
-        mode: 'loop',
         triggerSource,
         messagingSent,
         goalContext,
@@ -1497,10 +1505,7 @@ class AgentEngine {
         maxIterations,
       }),
       maxTokens: 320,
-      normalize: (raw) => normalizeCompletionDecision(raw, {
-        mode: 'loop',
-        fallbackStatus,
-      }),
+      normalize: (raw) => normalizeCompletionDecision(raw, fallbackStatus),
       fallback: { status: fallbackStatus },
       reasoningEffort: this.getReasoningEffort(providerName, options),
       telemetry: options,
@@ -1510,6 +1515,67 @@ class AgentEngine {
     return {
       decision: response.value,
       usage: response.usage,
+    };
+  }
+
+  async evaluateTaskCompleteSignal({
+    provider,
+    providerName,
+    model,
+    messages,
+    tools,
+    analysis,
+    plan,
+    toolExecutions,
+    finalMessage,
+    confidence,
+    triggerSource,
+    messagingSent,
+    iteration,
+    maxIterations,
+    options,
+  }) {
+    const runMeta = options?.runId ? this.getRunMeta(options.runId) : null;
+    const requiredConfidence = resolveRunGoalContext(runMeta, analysis, plan)
+      .effectiveCompletionConfidence;
+    const confidenceDecision = shouldAcceptTaskComplete({
+      confidence,
+      requiredConfidence,
+      iteration,
+      maxIterations,
+    });
+    if (!confidenceDecision.accept) {
+      return {
+        decision: {
+          status: 'continue',
+          reason: confidenceDecision.reason,
+        },
+        requiredConfidence,
+        usage: 0,
+      };
+    }
+
+    const loopState = await this.decideLoopState({
+      provider,
+      providerName,
+      model,
+      messages,
+      tools,
+      analysis,
+      plan,
+      toolExecutions,
+      lastReply: finalMessage,
+      triggerSource,
+      messagingSent,
+      iteration,
+      maxIterations,
+      options,
+      fallbackStatus: 'continue',
+    });
+    return {
+      decision: loopState.decision,
+      requiredConfidence,
+      usage: loopState.usage || 0,
     };
   }
 
@@ -1623,11 +1689,15 @@ class AgentEngine {
       }
     ];
 
-    const response = await provider.chat(promptMessages, [], {
-      model,
-      maxTokens: 800,
-      reasoningEffort: this.getReasoningEffort(providerName, options),
-    });
+    const response = await withModelCallTimeout(
+      provider.chat(promptMessages, [], {
+        model,
+        maxTokens: 800,
+        reasoningEffort: this.getReasoningEffort(providerName, options),
+      }),
+      options,
+      'Conversation state refresh',
+    );
     const parsed = parseJsonObject(response.content || '') || {};
     const nextState = {
       summary: String(parsed.summary || existingState?.summary || '').trim(),
@@ -1684,19 +1754,23 @@ class AgentEngine {
         `[Run ${shortenRunId(runId)}] blank_reply_recovery attempt=${attempt} model=${model}`
       );
       try {
-        const response = await provider.chat(
-          sanitizeConversationMessages([
-            ...messages,
+        const response = await withModelCallTimeout(
+          provider.chat(
+            sanitizeConversationMessages([
+              ...messages,
+              {
+                role: 'system',
+                content: buildBlankMessagingReplyPrompt(attempt, options?.source || null)
+              }
+            ]),
+            [],
             {
-              role: 'system',
-              content: buildBlankMessagingReplyPrompt(attempt, options?.source || null)
+              model,
+              reasoningEffort: this.getReasoningEffort(providerName, options)
             }
-          ]),
-          [],
-          {
-            model,
-            reasoningEffort: this.getReasoningEffort(providerName, options)
-          }
+          ),
+          options,
+          `Blank messaging reply recovery ${attempt}`,
         );
         totalTokens += response.usage?.totalTokens || 0;
         recoveredContent = sanitizeModelOutput(response.content || '', { model });
@@ -2127,169 +2201,6 @@ class AgentEngine {
     return { messages, appliedCount: queued.length };
   }
 
-  async decideMessagingCompletionState({
-    provider,
-    providerName,
-    model,
-    messages,
-    analysis,
-    plan,
-    tools,
-    toolExecutions,
-    lastReply,
-    iteration,
-    maxIterations,
-    runId,
-    options,
-  }) {
-    const runMeta = this.getRunMeta(runId);
-    const goalContext = resolveRunGoalContext(runMeta, analysis, plan);
-    const platform = options?.source || null;
-    const normalizedDraft = normalizeOutgoingMessage(lastReply || '', platform, {
-      collapseWhitespace: false,
-    });
-    const draftReply = normalizedDraft ? String(lastReply || '').trim() : '';
-    const ledger = runMeta?.progressLedger || null;
-    const progressSummary = [
-      `progress_state=${ledger?.progressState || 'active'}`,
-      `current_phase=${ledger?.currentPhase || 'idle'}`,
-      `current_tool=${ledger?.currentTool || 'none'}`,
-      `heartbeat_count=${Number(ledger?.heartbeatCount || 0)}`,
-      `last_visible_update=${ledger?.lastUserVisibleUpdateAt || 'none'}`,
-      `last_verified_progress=${ledger?.lastVerifiedProgressAt || 'none'}`,
-      `last_final_delivery=${ledger?.lastFinalDeliveryAt || 'none'}`,
-    ].join('; ');
-
-    const response = await this.requestStructuredJson({
-      provider,
-      providerName,
-      model,
-      messages,
-      prompt: buildCompletionDecisionPrompt({
-        mode: 'messaging',
-        goalContext,
-        parallelWork: analysis?.parallel_work === true,
-        tools,
-        toolExecutions,
-        lastReply: draftReply,
-        iteration,
-        maxIterations,
-        progressSummary,
-        platform,
-      }),
-      maxTokens: 480,
-      normalize: (raw) => normalizeCompletionDecision(raw, {
-        mode: 'messaging',
-        platform,
-        draftReply,
-      }),
-      fallback: {
-        status: 'continue',
-        reason: '',
-        final_reply: '',
-      },
-      reasoningEffort: this.getReasoningEffort(providerName, options),
-      telemetry: options,
-      phase: 'messaging_completion',
-    });
-
-    return {
-      decision: response.value,
-      usage: response.usage,
-    };
-  }
-
-  async resolveMessagingCompletionDecision({
-    provider,
-    providerName,
-    model,
-    messages,
-    analysis,
-    plan,
-    tools,
-    toolExecutions,
-    lastReply,
-    iteration,
-    maxIterations,
-    runId,
-    conversationId,
-    options,
-  }) {
-    const runMeta = this.getRunMeta(runId);
-    if (!shouldRequireMessagingFinalityCheck(runMeta)) {
-      return {
-        action: 'none',
-        content: lastReply,
-        reason: '',
-        usage: 0,
-      };
-    }
-
-    let completionDecision;
-    try {
-      completionDecision = await this.decideMessagingCompletionState({
-        provider,
-        providerName,
-        model,
-        messages,
-        analysis,
-        plan,
-        tools,
-        toolExecutions,
-        lastReply,
-        iteration,
-        maxIterations,
-        runId,
-        options,
-      });
-    } catch (error) {
-      if (iteration >= maxIterations) {
-        const wrapped = new Error(
-          `Messaging completion check failed after visible progress: ${error?.message || error}`,
-        );
-        wrapped.disableAutonomousRetry = error?.disableAutonomousRetry === true;
-        throw wrapped;
-      }
-      return {
-        action: 'continue',
-        content: '',
-        reason: 'The run still needs an explicit final result or blocker decision.',
-        usage: 0,
-      };
-    }
-
-    const decision = completionDecision.decision || { status: 'continue', reason: '' };
-    if (decision.status === 'continue') {
-      if (iteration >= maxIterations) {
-        throw new Error(
-          'Messaging run reached the iteration limit before producing a final answer or blocker after visible progress.',
-        );
-      }
-      return {
-        action: 'continue',
-        content: '',
-        reason: decision.reason || 'The current draft is still only progress.',
-        usage: completionDecision.usage || 0,
-      };
-    }
-
-    const finalContent = String(decision.final_reply || lastReply || '').trim();
-    if (finalContent && messages[messages.length - 1]?.role === 'assistant') {
-      messages[messages.length - 1] = {
-        ...messages[messages.length - 1],
-        content: finalContent,
-      };
-      this.replaceLatestConversationAssistantMessage(conversationId, finalContent);
-    }
-
-    return {
-      action: decision.status === 'blocked' ? 'blocked' : 'complete',
-      content: finalContent,
-      reason: decision.reason || '',
-      usage: completionDecision.usage || 0,
-    };
-  }
-
   buildMessagingHeartbeatText(runMeta, options = {}) {
     const stalled = options.stalled === true;
     const now = Date.now();
@@ -2327,7 +2238,7 @@ class AgentEngine {
 
     const createdAt = isoNow();
     const content = this.buildMessagingHeartbeatText(runMeta, options);
-    await this.messagingManager.sendMessage(
+    const deliveryResult = await this.messagingManager.sendMessage(
       runMeta.userId,
       runMeta.messagingContext.platform,
       runMeta.messagingContext.chatId,
@@ -2345,6 +2256,7 @@ class AgentEngine {
         deliveryKind: 'interim',
       },
     );
+    requireSuccessfulMessagingDelivery(deliveryResult, 'Messaging heartbeat delivery');
 
     runMeta.lastInterimMessage = content;
     if (!Array.isArray(runMeta.interimMessages)) {
@@ -2421,9 +2333,31 @@ class AgentEngine {
         await this.messagingManager.sendTyping(userId, platform, chatId, true, { agentId }).catch(() => {});
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
-      await this.messagingManager.sendMessage(userId, platform, chatId, chunks[i], { runId, agentId }).catch((err) =>
-        console.error('[Engine] Auto-reply fallback failed:', err.message)
-      );
+      try {
+        await withProviderRetry(async () => {
+          const deliveryResult = await this.messagingManager.sendMessage(
+            userId,
+            platform,
+            chatId,
+            chunks[i],
+            { runId, agentId },
+          );
+          return requireSuccessfulMessagingDelivery(deliveryResult, 'Final messaging delivery');
+        }, {
+          ...this.messagingDeliveryRetry,
+          label: `MessagingDelivery ${platform}`,
+          isRetryable: (error) => (
+            error?.retryable !== false
+            && (
+              error?.code === 'MESSAGING_DELIVERY_FAILED'
+              || isTransientError(error)
+            )
+          ),
+        });
+      } catch (error) {
+        error.disableAutonomousRetry = true;
+        throw error;
+      }
     }
 
     runMeta.lastSentMessage = chunks[chunks.length - 1] || cleanedContent;
@@ -2474,7 +2408,10 @@ class AgentEngine {
       return { sent: false, skipped: true };
     }
 
-    if (ledger.currentPhase === 'tool' && ledger.currentStepStartedAt) {
+    if (
+      (ledger.currentPhase === 'tool' || ledger.currentPhase === 'model')
+      && ledger.currentStepStartedAt
+    ) {
       return this.sendRuntimeMessagingHeartbeat(runId, { stalled });
     }
 
@@ -2788,7 +2725,12 @@ class AgentEngine {
     const carriedExplicitMessageSent = retryMessagingState.explicitMessageSent === true;
     const carriedInterimHistory = cloneInterimHistory(retryMessagingState.interimHistory);
     const carriedLastInterimMessage = carriedInterimHistory[carriedInterimHistory.length - 1]?.content || '';
-    const carriedGoalContract = normalizeGoalContract(retryMessagingState.goalContract);
+    const carriedGoalContract = mergeGoalContracts(
+      normalizeGoalContract({
+        goal: clampRunContext(userMessage, 1200),
+      }),
+      retryMessagingState.goalContract,
+    );
     const startedAtIso = isoNow();
     const progressLedger = buildInitialProgressLedger({
       startedAt: startedAtIso,
@@ -3223,6 +3165,37 @@ class AgentEngine {
           db.prepare('INSERT INTO conversation_messages (conversation_id, role, content, tokens) VALUES (?, ?, ?, ?)')
             .run(conversationId, 'assistant', lastContent, analysisUsage);
         }
+        const directAnswerDecision = await runWithModelFallback(
+          'direct answer completion decision',
+          () => this.decideLoopState({
+            provider,
+            providerName,
+            model,
+            messages,
+            tools,
+            analysis,
+            plan,
+            toolExecutions,
+            lastReply: lastContent,
+            triggerSource,
+            messagingSent: false,
+            iteration,
+            maxIterations,
+            options: { ...options, runId, userId, agentId },
+            fallbackStatus: 'continue',
+          }),
+        );
+        totalTokens += directAnswerDecision.usage || 0;
+        if (directAnswerDecision.decision.status === 'continue') {
+          messages.push({
+            role: 'system',
+            content: directAnswerDecision.decision.reason
+              ? `Continue working: ${directAnswerDecision.decision.reason}.`
+              : 'The initial draft is not a finished answer. Continue working autonomously.',
+          });
+          lastContent = '';
+          directAnswerEligible = false;
+        }
       }
 
       // BUG FIX: consecutiveToolFailures was previously declared INSIDE the
@@ -3248,14 +3221,16 @@ class AgentEngine {
           currentStep: `model:${iteration}`,
           currentTool: null,
           currentStepStartedAt: isoNow(),
-        }, {
-          verified: true,
         });
 
         let metrics = this.estimatePromptMetrics(messages, tools);
         const contextWindow = provider.getContextWindow(model);
         if (metrics.totalEstimatedTokens > contextWindow * loopPolicy.compactionThreshold) {
-          messages = await compact(messages, provider, model, contextWindow);
+          messages = await withModelCallTimeout(
+            compact(messages, provider, model, contextWindow),
+            options,
+            `Context compaction before iteration ${iteration}`,
+          );
           messages = sanitizeConversationMessages(messages);
           this.emit(userId, 'run:compaction', { runId, iteration });
           metrics = this.estimatePromptMetrics(messages, tools);
@@ -3393,6 +3368,9 @@ class AgentEngine {
           toolCallCount: response.toolCalls?.length || 0,
           contentPreview: String(lastContent || streamContent || '').slice(0, 240),
         }, { agentId });
+        this.updateRunProgress(runId, {}, {
+          verified: true,
+        });
 
         const assistantMessage = { role: 'assistant', content: lastContent };
         if (response.toolCalls?.length) assistantMessage.tool_calls = response.toolCalls;
@@ -3416,8 +3394,6 @@ class AgentEngine {
             currentStep: null,
             currentTool: null,
             currentStepStartedAt: null,
-          }, {
-            verified: true,
           });
           const systemSteeringAfterResponse = this.applyQueuedSystemSteering(runId, messages);
           messages = systemSteeringAfterResponse.messages;
@@ -3446,88 +3422,54 @@ class AgentEngine {
           })) {
             break;
           }
-          const runMetaAfterResponse = this.getRunMeta(runId);
-          if (shouldRequireMessagingFinalityCheck(runMetaAfterResponse)) {
-            const messagingCompletion = await this.resolveMessagingCompletionDecision({
-              provider,
-              providerName,
-              model,
-              messages,
-              analysis,
-              plan,
-              tools,
-              toolExecutions,
-              lastReply: lastContent,
-              iteration,
-              maxIterations,
-              runId,
-              conversationId,
-              options: { ...options, runId, userId, agentId },
+          const proactiveRunNeedsDecision = (
+            (triggerSource === 'schedule' || triggerSource === 'tasks')
+            && this.activeRuns.get(runId)?.noResponse !== true
+            && options.deliveryState?.noResponse !== true
+          );
+          const visibleInterimActivity = hasVisibleInterimActivity(this.activeRuns.get(runId));
+          const fallbackStatus = (
+            proactiveRunNeedsDecision
+            || toolExecutions.length > 0
+            || failedStepCount > 0
+            || messagingSent
+            || visibleInterimActivity
+          ) ? 'continue' : 'complete';
+          const loopState = await runWithModelFallback('loop decision', () => this.decideLoopState({
+            provider,
+            providerName,
+            model,
+            messages,
+            tools,
+            analysis,
+            plan,
+            toolExecutions,
+            lastReply: lastContent,
+            triggerSource,
+            messagingSent,
+            iteration,
+            maxIterations,
+            options: { ...options, runId, userId, agentId },
+            fallbackStatus,
+          }));
+          totalTokens += loopState.usage || 0;
+          if (loopState.decision.status === 'continue') {
+            if (iteration >= maxIterations) {
+              throw new Error(
+                `Completion judge found unfinished work at the iteration limit after ${maxIterations} iterations.`,
+              );
+            }
+            messages.push({
+              role: 'system',
+              content: [
+                loopState.decision.reason ? `Continue working: ${loopState.decision.reason}.` : 'Continue working autonomously.',
+                messagingSent
+                  ? 'You already sent a user-facing message in this run. Keep working silently unless you have a materially new finished result or a real external blocker.'
+                  : 'Use send_interim_update sparingly if a short real update or question would help. Otherwise keep working until you have the result or a real blocker.',
+              ].join(' ')
             });
-            totalTokens += messagingCompletion.usage || 0;
-            if (messagingCompletion.action === 'continue') {
-              messages.push({
-                role: 'system',
-                content: [
-                  messagingCompletion.reason
-                    ? `Continue working: ${messagingCompletion.reason}.`
-                    : 'Continue working autonomously.',
-                  'The messaging user has already seen progress. Do not stop until you either have the finished answer now or a concrete blocker reply now.',
-                ].join(' ')
-              });
-              lastContent = '';
-              continue;
-            }
-            if (typeof messagingCompletion.content === 'string') {
-              lastContent = messagingCompletion.content;
-            }
-            break;
-          }
-          if (iteration < maxIterations) {
-            const proactiveRunNeedsDecision = (
-              (triggerSource === 'schedule' || triggerSource === 'tasks')
-              && this.activeRuns.get(runId)?.noResponse !== true
-              && options.deliveryState?.noResponse !== true
-            );
-            const visibleInterimActivity = hasVisibleInterimActivity(this.activeRuns.get(runId));
-            const fallbackStatus = (
-              proactiveRunNeedsDecision
-              || toolExecutions.length > 0
-              || failedStepCount > 0
-              || messagingSent
-              || visibleInterimActivity
-            ) ? 'continue' : 'complete';
-            const loopState = await runWithModelFallback('loop decision', () => this.decideLoopState({
-              provider,
-              providerName,
-              model,
-              messages,
-              tools,
-              analysis,
-              plan,
-              toolExecutions,
-              lastReply: lastContent,
-              triggerSource,
-              messagingSent,
-              iteration,
-              maxIterations,
-              options: { ...options, runId, userId, agentId },
-              fallbackStatus,
-            }));
-            totalTokens += loopState.usage || 0;
-            if (loopState.decision.status === 'continue') {
-              messages.push({
-                role: 'system',
-                content: [
-                  loopState.decision.reason ? `Continue working: ${loopState.decision.reason}.` : 'Continue working autonomously.',
-                  messagingSent
-                    ? 'You already sent a user-facing message in this run. Keep working silently unless you have a materially new finished result or a real external blocker.'
-                    : 'Use send_interim_update sparingly if a short real update or question would help. Otherwise keep working until you have the result or a real blocker.',
-                ].join(' ')
-              });
-              lastContent = '';
-              continue;
-            }
+            lastContent = '';
+            continue;
           }
           break;
         }
@@ -3537,6 +3479,15 @@ class AgentEngine {
           && response.toolCalls.every((toolCall) => this.isReadOnlyToolCall(toolCall))
         );
         if (canRunParallelBatch) {
+          const parallelToolNames = response.toolCalls
+            .map((toolCall) => toolCall.function?.name)
+            .filter(Boolean);
+          this.updateRunProgress(runId, {
+            currentPhase: 'tool',
+            currentStep: `parallel:${iteration}`,
+            currentTool: parallelToolNames.join(', ') || 'parallel tools',
+            currentStepStartedAt: isoNow(),
+          });
           const batch = await this.executeReadOnlyBatch(response.toolCalls, {
             userId,
             runId,
@@ -3588,6 +3539,14 @@ class AgentEngine {
             deliverableArtifacts,
             compactionMetrics: compactionMetrics.slice(-20),
           });
+          this.updateRunProgress(runId, {
+            currentPhase: 'idle',
+            currentStep: null,
+            currentTool: null,
+            currentStepStartedAt: null,
+          }, {
+            verified: true,
+          });
           continue;
         }
 
@@ -3610,23 +3569,51 @@ class AgentEngine {
           if (toolName === 'task_complete') {
             const finalMessage = String(toolArgs.message || '').trim();
             const confidence = normalizeCompletionConfidence(toolArgs.confidence || 'medium');
-            const completionDecision = shouldAcceptTaskComplete({
-              confidence,
-              requiredConfidence: analysis?.completion_confidence_required || 'medium',
-              iteration,
-              maxIterations,
-            });
+            const messagingSent = this.getRunMeta(runId)?.messagingSent === true;
+            const completionResult = await runWithModelFallback(
+              'task completion decision',
+              () => this.evaluateTaskCompleteSignal({
+                provider,
+                providerName,
+                model,
+                messages,
+                tools,
+                analysis,
+                plan,
+                toolExecutions,
+                finalMessage,
+                confidence,
+                triggerSource,
+                messagingSent,
+                iteration,
+                maxIterations,
+                options: { ...options, runId, userId, agentId },
+              }),
+            );
+            totalTokens += completionResult.usage || 0;
+            const completionDecision = completionResult.decision || {
+              status: 'continue',
+              reason: 'The completion signal could not be verified.',
+            };
+            const accepted = completionDecision.status !== 'continue';
             this.recordRunEvent(userId, runId, 'task_complete_signaled', {
               confidence,
-              requiredConfidence: analysis?.completion_confidence_required || 'medium',
-              accepted: completionDecision.accept,
+              requiredConfidence: completionResult.requiredConfidence,
+              accepted,
+              judgeStatus: completionDecision.status,
+              judgeReason: completionDecision.reason || '',
               iteration,
               messageLength: finalMessage.length,
             }, { agentId });
             console.info(
-              `[Run ${shortenRunId(runId)}] task_complete signaled at iteration=${iteration} confidence=${confidence} accepted=${completionDecision.accept}`
+              `[Run ${shortenRunId(runId)}] task_complete signaled at iteration=${iteration} confidence=${confidence} judge=${completionDecision.status} accepted=${accepted}`
             );
-            if (!completionDecision.accept) {
+            if (!accepted) {
+              if (iteration >= maxIterations) {
+                throw new Error(
+                  `Completion judge rejected task_complete at the iteration limit after ${maxIterations} iterations.`,
+                );
+              }
               messages.push({
                 role: 'tool',
                 name: toolName,
@@ -3634,13 +3621,14 @@ class AgentEngine {
                 content: JSON.stringify({
                   status: 'continue',
                   reason: completionDecision.reason,
-                  required_confidence: analysis?.completion_confidence_required || 'medium',
+                  required_confidence: completionResult.requiredConfidence,
                 }),
               });
               messages.push({
                 role: 'system',
                 content: `${completionDecision.reason} Do not ask the user to decide the next step unless external input is truly required.`
               });
+              lastContent = '';
               continue;
             }
             if (completionDecision.reason) {
@@ -3712,7 +3700,6 @@ class AgentEngine {
             currentTool: toolName,
             currentStepStartedAt: isoNow(),
           }, {
-            verified: true,
             stepId,
           });
 
@@ -4139,20 +4126,6 @@ class AgentEngine {
           refreshConversationSummary(conversationId, provider, model, historyWindow).catch((err) => {
             console.error('[AI] Conversation summary refresh failed:', err.message);
           });
-          await this.refreshConversationState({
-            conversationId,
-            runId,
-            provider,
-            providerName,
-            model,
-            finalReply: finalResponseText,
-            analysis,
-            verification,
-            historyWindow,
-            options: { ...options, userId, agentId },
-          }).catch((err) => {
-            console.error('[AI] Conversation working state refresh failed:', err.message);
-          });
         }
       }
 
@@ -4184,6 +4157,23 @@ class AgentEngine {
             content: lastContent || '',
           });
         }
+      }
+
+      if (conversationId && options.skipConversationMaintenance !== true) {
+        await this.refreshConversationState({
+          conversationId,
+          runId,
+          provider,
+          providerName,
+          model,
+          finalReply: finalResponseText,
+          analysis,
+          verification,
+          historyWindow,
+          options: { ...options, userId, agentId },
+        }).catch((err) => {
+          console.error('[AI] Conversation working state refresh failed:', err.message);
+        });
       }
 
       console.info(
@@ -4272,6 +4262,8 @@ class AgentEngine {
         triggerSource === 'messaging'
         && options.source
         && options.chatId
+        && runMeta?.finalDeliverySent !== true
+        && runMeta?.messagingSent !== true
         && err?.disableAutonomousRetry !== true
         && !isRateLimitError
         && retryCount < this.getMessagingRetryLimit(maxIterations)
@@ -4342,7 +4334,7 @@ class AgentEngine {
       let messagingFailureContent = '';
       let sendSucceeded = false;
       if (triggerSource === 'messaging' && options.source && options.chatId) {
-        if (!runMeta?.messagingSent) {
+        if (!runMeta?.finalDeliverySent && !runMeta?.messagingSent) {
           const manager = this.messagingManager;
           if (manager) {
             const failureScenario = buildMessagingFailureScenario({
@@ -4359,10 +4351,14 @@ class AgentEngine {
                   content: `The run encountered a runtime error and cannot continue reliably. Use the actual run scenario below to explain the blocker naturally.\n\nScenario:\n${failureScenario || 'No additional scenario details were captured.'}\n\nDo not call tools. Write exactly one short user message. Do not ask the user to resend or restate the same task. Only ask the user for something if a specific external input, permission, or configuration change is actually required. Do not promise future work unless it will happen automatically before this reply is sent.\n\n${buildPlatformFormattingGuide(options?.source || null)}`
                 }
               ]);
-              const modelReply = await provider.chat(failedMessage, [], {
-                model,
-                reasoningEffort: this.getReasoningEffort(providerName, options)
-              });
+              const modelReply = await withModelCallTimeout(
+                provider.chat(failedMessage, [], {
+                  model,
+                  reasoningEffort: this.getReasoningEffort(providerName, options)
+                }),
+                options,
+                'Messaging failure reply',
+              );
               const drafted = sanitizeModelOutput(modelReply.content || '', { model });
               if (normalizeOutgoingMessage(drafted, options?.source || null)) {
                 messagingFailureContent = drafted.trim();
@@ -4381,7 +4377,14 @@ class AgentEngine {
             }
 
             try {
-              await manager.sendMessage(userId, options.source, options.chatId, messagingFailureContent, { runId, agentId });
+              const deliveryResult = await manager.sendMessage(
+                userId,
+                options.source,
+                options.chatId,
+                messagingFailureContent,
+                { runId, agentId },
+              );
+              requireSuccessfulMessagingDelivery(deliveryResult, 'Messaging failure delivery');
               sendSucceeded = true;
               if (runMeta) {
                 runMeta.lastSentMessage = messagingFailureContent;

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -3785,7 +3785,7 @@ class AgentEngine {
             throw new Error(`Iteration limit reached before explicit completion after ${maxIterations} iterations.`);
           }
         }
-        if (stepIndex > 0 && !lastToolWasMessaging) {
+        if (stepIndex > 0 && !lastToolWasMessaging && iteration < maxIterations) {
           throw new Error('Run ended without an explicit completion or blocker reply.');
         }
       }

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -168,6 +168,16 @@ function buildErrorPatternGuidance(key, count) {
   return `REPEATED ERROR (${count}×): ${guide}`;
 }
 
+// Tools that definitely produce real output and reset the stagnation counter.
+// Everything NOT matched is treated as read/observe — conservative in the right
+// direction (under-counting stagnation is safer than over-counting it).
+const DEFINITELY_MUTATING_PATTERN = /^(write_file|create_file|append_file|patch_file|delete_file|move_file|copy_file|send_message|send_interim_update|make_call|memory_save|memory_update|memory_delete|create_task|update_task|delete_task|task_complete|save_widget_snapshot|github_create_|github_update_|github_merge_|github_close_|github_delete_|github_push_|github_create_branch|github_delete_branch|github_create_commit|subagent_create|subagent_cancel|create_|write_|update_|delete_|send_|push_|commit_|publish_|deploy_)/;
+
+function isDefinitelyMutating(toolName) {
+  if (!toolName) return false;
+  return DEFINITELY_MUTATING_PATTERN.test(toolName);
+}
+
 function resolveModelCallTimeoutMs(options = {}) {
   const requested = Number(options?.modelCallTimeoutMs);
   if (Number.isFinite(requested) && requested > 0) {
@@ -3029,10 +3039,12 @@ class AgentEngine {
       // full run so the failure guard fires correctly after 5 consecutive failures
       // regardless of which iteration they fall in.
       let consecutiveToolFailures = 0;
+      let stagnantIterations = 0;
 
       while (!directAnswerEligible && iteration < maxIterations) {
         if (this.isRunStopped(runId)) break;
         iteration++;
+        let iterationHadMutatingTool = false;
 
         const systemSteeringAtLoopStart = this.applyQueuedSystemSteering(runId, messages);
         messages = systemSteeringAtLoopStart.messages;
@@ -3328,6 +3340,8 @@ class AgentEngine {
           }, {
             verified: true,
           });
+          // Parallel batch is always read-only — always counts as stagnant.
+          stagnantIterations++;
           continue;
         }
 
@@ -3646,6 +3660,10 @@ class AgentEngine {
             }
           }
 
+          if (!toolErrorMessage && isDefinitelyMutating(toolName)) {
+            iterationHadMutatingTool = true;
+          }
+
           if (toolName === 'save_widget_snapshot' && !toolErrorMessage) {
             lastContent = 'Widget snapshot updated.';
             break;
@@ -3653,6 +3671,35 @@ class AgentEngine {
 
           if (runMeta?.terminalInterim) {
             break;
+          }
+        }
+
+        // ── Stagnation detection ──────────────────────────────────────────────
+        if (iterationHadMutatingTool) {
+          stagnantIterations = 0;
+        } else {
+          stagnantIterations++;
+          if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
+            stagnantIterations = 0;
+            console.warn(
+              `[Run ${shortenRunId(runId)}] stagnation at iteration=${iteration} — steering + compaction`
+            );
+            this.enqueueSystemSteering(
+              runId,
+              `You have spent ${loopPolicy.maxStagnantIterations} consecutive turns making only read/observe calls without writing, creating, or sending anything. Stop gathering information and take direct action now.`,
+              { reason: 'stagnation' },
+            );
+            const stagnantMetrics = this.estimatePromptMetrics(messages, tools);
+            const stagnantCtxWindow = provider.getContextWindow(model);
+            if (stagnantMetrics.totalEstimatedTokens > stagnantCtxWindow * 0.5) {
+              messages = await withModelCallTimeout(
+                compact(messages, provider, model, stagnantCtxWindow),
+                options,
+                `Context compaction on stagnation at iteration ${iteration}`,
+              );
+              messages = sanitizeConversationMessages(messages);
+              this.emit(userId, 'run:compaction', { runId, iteration });
+            }
           }
         }
 

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -112,6 +112,80 @@ function buildInitialRunMetadata(options = {}) {
   return metadata;
 }
 
+const MESSAGING_PROGRESS_FIRST_UPDATE_MS = 60 * 1000;
+const MESSAGING_PROGRESS_REPEAT_MS = 90 * 1000;
+const MESSAGING_PROGRESS_STALL_MS = 240 * 1000;
+const MESSAGING_PROGRESS_TICK_MS = 15 * 1000;
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function timestampMs(value, fallback = 0) {
+  const resolved = value ? Date.parse(value) : NaN;
+  return Number.isFinite(resolved) ? resolved : fallback;
+}
+
+function formatElapsedDuration(durationMs) {
+  const totalSeconds = Math.max(1, Math.floor(Number(durationMs || 0) / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (seconds === 0) return `${minutes}m`;
+  return `${minutes}m ${seconds}s`;
+}
+
+function cloneInterimHistory(history = []) {
+  if (!Array.isArray(history)) return [];
+  return history.map((item) => ({
+    content: String(item?.content || '').trim(),
+    kind: normalizeInterimKind(item?.kind),
+    expectsReply: item?.expectsReply === true,
+    deferFollowUp: item?.deferFollowUp === true,
+    createdAt: item?.createdAt || isoNow(),
+  })).filter((item) => item.content);
+}
+
+function createInterimSignatureSet(history = [], platform = null) {
+  const signatures = new Set();
+  for (const item of cloneInterimHistory(history)) {
+    signatures.add(buildInterimSignature({
+      content: item.content,
+      kind: item.kind,
+      expectsReply: item.expectsReply === true,
+      platform,
+    }));
+  }
+  return signatures;
+}
+
+function buildInitialProgressLedger({ startedAt, retryState = {} } = {}) {
+  const startedAtIso = startedAt || isoNow();
+  const interimHistory = cloneInterimHistory(retryState.interimHistory);
+  const lastInterimMessage = interimHistory[interimHistory.length - 1]?.content || '';
+  const lastVisibleAt = retryState.lastUserVisibleUpdateAt || (lastInterimMessage ? startedAtIso : null);
+  return {
+    currentStep: retryState.currentStep || null,
+    currentTool: retryState.currentTool || null,
+    currentStepStartedAt: retryState.currentStepStartedAt || null,
+    lastVerifiedProgressAt: retryState.lastVerifiedProgressAt || startedAtIso,
+    lastUserVisibleUpdateAt: lastVisibleAt,
+    lastFinalDeliveryAt: retryState.lastFinalDeliveryAt || null,
+    heartbeatCount: Number(retryState.heartbeatCount || 0),
+    stallNotifiedAt: retryState.stallNotifiedAt || null,
+    progressState: retryState.progressState || 'active',
+    currentPhase: retryState.currentPhase || 'idle',
+  };
+}
+
+function hasVisibleInterimActivity(runMeta) {
+  return Boolean(
+    runMeta?.lastInterimMessage
+    || (Array.isArray(runMeta?.interimMessages) && runMeta.interimMessages.length > 0)
+    || Number(runMeta?.progressLedger?.heartbeatCount || 0) > 0
+  );
+}
+
 function planningDepthForForceMode(forceMode) {
   return forceMode === 'plan_execute' ? 'deep' : 'light';
 }
@@ -555,6 +629,97 @@ class AgentEngine {
       .run(JSON.stringify(next), runId);
   }
 
+  buildProgressLedgerSnapshot(runMeta) {
+    if (!runMeta?.progressLedger) return null;
+    return {
+      currentStep: runMeta.progressLedger.currentStep || null,
+      currentTool: runMeta.progressLedger.currentTool || null,
+      currentStepStartedAt: runMeta.progressLedger.currentStepStartedAt || null,
+      lastVerifiedProgressAt: runMeta.progressLedger.lastVerifiedProgressAt || null,
+      lastUserVisibleUpdateAt: runMeta.progressLedger.lastUserVisibleUpdateAt || null,
+      lastFinalDeliveryAt: runMeta.progressLedger.lastFinalDeliveryAt || null,
+      heartbeatCount: Number(runMeta.progressLedger.heartbeatCount || 0),
+      stallNotifiedAt: runMeta.progressLedger.stallNotifiedAt || null,
+      progressState: runMeta.progressLedger.progressState || 'active',
+      currentPhase: runMeta.progressLedger.currentPhase || 'idle',
+    };
+  }
+
+  persistProgressLedger(runId) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta?.progressLedger) return;
+    this.persistRunMetadata(runId, {
+      progressLedger: this.buildProgressLedgerSnapshot(runMeta),
+    });
+  }
+
+  updateRunProgress(runId, patch = {}, options = {}) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta) return null;
+    if (!runMeta.progressLedger) {
+      runMeta.progressLedger = buildInitialProgressLedger({
+        startedAt: runMeta.startedAtIso || isoNow(),
+      });
+    }
+
+    const previousState = runMeta.progressLedger.progressState || 'active';
+    runMeta.progressLedger = {
+      ...runMeta.progressLedger,
+      ...patch,
+    };
+
+    if (options.verified === true) {
+      runMeta.progressLedger.lastVerifiedProgressAt = options.timestamp || isoNow();
+      runMeta.progressLedger.progressState = 'active';
+      runMeta.progressLedger.stallNotifiedAt = null;
+      this.recordRunEvent(runMeta.userId, runId, 'progress_verified', {
+        phase: runMeta.progressLedger.currentPhase || 'idle',
+        currentStep: runMeta.progressLedger.currentStep || null,
+        currentTool: runMeta.progressLedger.currentTool || null,
+      }, { agentId: runMeta.agentId, stepId: options.stepId || null });
+      if (previousState === 'stalled') {
+        this.recordRunEvent(runMeta.userId, runId, 'progress_resumed', {
+          phase: runMeta.progressLedger.currentPhase || 'idle',
+          currentStep: runMeta.progressLedger.currentStep || null,
+          currentTool: runMeta.progressLedger.currentTool || null,
+        }, { agentId: runMeta.agentId, stepId: options.stepId || null });
+      }
+    }
+
+    if (options.persist !== false) {
+      this.persistProgressLedger(runId);
+    }
+    return runMeta.progressLedger;
+  }
+
+  markRunVisibleProgress(runId, timestamp = isoNow()) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta) return null;
+    const ledger = this.updateRunProgress(runId, {
+      lastUserVisibleUpdateAt: timestamp,
+    }, {
+      persist: false,
+    });
+    this.persistProgressLedger(runId);
+    return ledger;
+  }
+
+  markRunFinalDelivery(runId, content = '', timestamp = isoNow()) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta) return null;
+    runMeta.finalDeliverySent = true;
+    runMeta.lastSentMessage = String(content || '').trim() || runMeta.lastSentMessage || '';
+    const ledger = this.updateRunProgress(runId, {
+      lastUserVisibleUpdateAt: timestamp,
+      lastFinalDeliveryAt: timestamp,
+      progressState: 'complete',
+    }, {
+      persist: false,
+    });
+    this.persistProgressLedger(runId);
+    return ledger;
+  }
+
   recordRunEvent(userId, runId, eventType, payload = {}, options = {}) {
     try {
       return recordRunEvent({
@@ -695,6 +860,7 @@ class AgentEngine {
       createdAt,
     });
     runMeta.lastInterimMessage = normalizedContent;
+    this.markRunVisibleProgress(runId, createdAt);
 
     this.emit(userId, 'run:assistant_interim', {
       runId,
@@ -722,6 +888,7 @@ class AgentEngine {
         content: normalizedContent,
         createdAt,
       },
+      progressLedger: this.buildProgressLedgerSnapshot(runMeta),
       terminalInterim: terminalInterim
         ? { kind: normalizedKind, content: normalizedContent, createdAt }
         : null,
@@ -1584,6 +1751,45 @@ class AgentEngine {
     };
   }
 
+  enqueueSystemSteering(runId, content, metadata = {}) {
+    const runMeta = this.getRunMeta(runId);
+    const trimmed = typeof content === 'string' ? content.trim() : '';
+    if (!runMeta || runMeta.aborted || !trimmed) return null;
+    if (!Array.isArray(runMeta.systemSteeringQueue)) {
+      runMeta.systemSteeringQueue = [];
+    }
+    const signature = JSON.stringify({
+      content: trimmed,
+      reason: metadata.reason || '',
+    });
+    if (runMeta.systemSteeringQueue.some((item) => item.signature === signature)) {
+      return null;
+    }
+    const item = {
+      id: uuidv4(),
+      content: trimmed,
+      metadata,
+      signature,
+      createdAt: isoNow(),
+    };
+    runMeta.systemSteeringQueue.push(item);
+    return item;
+  }
+
+  applyQueuedSystemSteering(runId, messages) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta?.systemSteeringQueue?.length) {
+      return { messages, appliedCount: 0 };
+    }
+
+    const queued = runMeta.systemSteeringQueue.splice(0, runMeta.systemSteeringQueue.length);
+    for (const entry of queued) {
+      messages.push({ role: 'system', content: entry.content });
+    }
+
+    return { messages, appliedCount: queued.length };
+  }
+
   applyQueuedSteering(runId, messages, { userId, conversationId }) {
     const runMeta = this.getRunMeta(runId);
     if (!runMeta?.steeringQueue?.length) {
@@ -1617,6 +1823,242 @@ class AgentEngine {
     });
 
     return { messages, appliedCount: queued.length };
+  }
+
+  buildMessagingHeartbeatText(runMeta, options = {}) {
+    const stalled = options.stalled === true;
+    const fallbackStartedAtMs = Number.isFinite(runMeta?.startedAt) ? runMeta.startedAt : Date.now();
+    const startedAtMs = timestampMs(
+      runMeta?.progressLedger?.currentStepStartedAt,
+      fallbackStartedAtMs,
+    );
+    const elapsed = formatElapsedDuration(Date.now() - startedAtMs);
+    const currentTool = String(runMeta?.progressLedger?.currentTool || '').trim();
+    if (currentTool) {
+      return stalled
+        ? `Still working on ${currentTool}. This run has not made verified progress for ${elapsed}.`
+        : `Still working on ${currentTool}. ${elapsed} elapsed so far.`;
+    }
+    return stalled
+      ? `Still working on this. This run has not made verified progress for ${elapsed}.`
+      : `Still working on this. ${elapsed} elapsed so far.`;
+  }
+
+  async sendRuntimeMessagingHeartbeat(runId, options = {}) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta || runMeta.aborted) return { sent: false, skipped: true };
+    if (runMeta.triggerSource !== 'messaging' || !runMeta.messagingContext?.platform || !runMeta.messagingContext?.chatId) {
+      return { sent: false, skipped: true };
+    }
+    if (!this.messagingManager) {
+      return { sent: false, skipped: true };
+    }
+
+    const createdAt = isoNow();
+    const content = this.buildMessagingHeartbeatText(runMeta, options);
+    await this.messagingManager.sendMessage(
+      runMeta.userId,
+      runMeta.messagingContext.platform,
+      runMeta.messagingContext.chatId,
+      content,
+      {
+        agentId: runMeta.agentId,
+        runId,
+        persistConversation: true,
+        metadata: {
+          interim: true,
+          interim_kind: options.stalled === true ? 'blocker' : 'progress',
+          runtime_heartbeat: true,
+          expects_reply: false,
+        },
+        deliveryKind: 'interim',
+      },
+    );
+
+    runMeta.lastInterimMessage = content;
+    if (!Array.isArray(runMeta.interimMessages)) {
+      runMeta.interimMessages = [];
+    }
+    runMeta.interimMessages.push({
+      content,
+      kind: options.stalled === true ? 'blocker' : 'progress',
+      expectsReply: false,
+      deferFollowUp: false,
+      createdAt,
+    });
+    const heartbeatCount = Number(runMeta.progressLedger?.heartbeatCount || 0) + 1;
+    this.updateRunProgress(runId, {
+      heartbeatCount,
+      lastUserVisibleUpdateAt: createdAt,
+    });
+    this.recordRunEvent(runMeta.userId, runId, 'progress_heartbeat_sent', {
+      stalled: options.stalled === true,
+      currentTool: runMeta.progressLedger?.currentTool || null,
+      currentStep: runMeta.progressLedger?.currentStep || null,
+    }, { agentId: runMeta.agentId });
+    this.enqueueSystemSteering(
+      runId,
+      'A runtime-generated progress update was already sent while the run was blocked. Do not repeat that same status. When control returns, either keep working silently, send a materially new update, or finish with the actual result.',
+      { reason: 'runtime_heartbeat' },
+    );
+    return { sent: true, content };
+  }
+
+  shouldSendMessagingFinalFallback(runMeta, content, platform = null) {
+    const cleanedContent = normalizeOutgoingMessage(content || '', platform, {
+      collapseWhitespace: false,
+    });
+    const lastFinalDeliveryMessage = normalizeOutgoingMessage(
+      runMeta?.lastSentMessage
+      || (Array.isArray(runMeta?.sentMessages) ? runMeta.sentMessages[runMeta.sentMessages.length - 1] : '')
+      || '',
+      platform,
+    );
+    return Boolean(
+      cleanedContent
+      && !runMeta?.terminalInterim
+      && runMeta?.explicitMessageSent !== true
+      && runMeta?.finalDeliverySent !== true
+      && !lastFinalDeliveryMessage
+    );
+  }
+
+  async deliverMessagingFinalFallback({
+    runId,
+    userId,
+    agentId,
+    platform,
+    chatId,
+    content,
+  }) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta || !this.messagingManager) return { sent: false, skipped: true };
+    const cleanedContent = normalizeOutgoingMessage(content || '', platform, {
+      collapseWhitespace: false,
+    });
+    if (!this.shouldSendMessagingFinalFallback(runMeta, cleanedContent, platform)) {
+      return { sent: false, skipped: true };
+    }
+
+    const chunks = splitOutgoingMessageForPlatform(platform, cleanedContent);
+    console.info(
+      `[Run ${shortenRunId(runId)}] messaging_fallback chunks=${chunks.length} to=${summarizeForLog(chatId, 80)}`
+    );
+    for (let i = 0; i < chunks.length; i++) {
+      if (i > 0) {
+        const delay = Math.max(1000, Math.min(chunks[i].length * 30, 4000));
+        await this.messagingManager.sendTyping(userId, platform, chatId, true, { agentId }).catch(() => {});
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      await this.messagingManager.sendMessage(userId, platform, chatId, chunks[i], { runId, agentId }).catch((err) =>
+        console.error('[Engine] Auto-reply fallback failed:', err.message)
+      );
+    }
+
+    runMeta.lastSentMessage = chunks[chunks.length - 1] || cleanedContent;
+    runMeta.sentMessages = Array.isArray(runMeta.sentMessages)
+      ? [...runMeta.sentMessages, ...chunks]
+      : chunks.slice();
+    this.markRunFinalDelivery(runId, runMeta.lastSentMessage);
+    return { sent: true, chunks };
+  }
+
+  async tickMessagingProgressSupervisor(runId) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta || runMeta.aborted || runMeta.triggerSource !== 'messaging') {
+      return { sent: false, skipped: true };
+    }
+    if (runMeta.finalDeliverySent === true || runMeta.terminalInterim) {
+      return { sent: false, skipped: true };
+    }
+
+    const now = Date.now();
+    const ledger = runMeta.progressLedger || buildInitialProgressLedger({
+      startedAt: runMeta.startedAtIso || isoNow(),
+    });
+    runMeta.progressLedger = ledger;
+    const startedAtMs = Number.isFinite(runMeta.startedAt) ? runMeta.startedAt : now;
+
+    const lastVerifiedAtMs = timestampMs(ledger.lastVerifiedProgressAt, startedAtMs);
+    const lastVisibleAtMs = timestampMs(ledger.lastUserVisibleUpdateAt, 0);
+    const heartbeatThresholdMs = lastVisibleAtMs > 0
+      ? MESSAGING_PROGRESS_REPEAT_MS
+      : MESSAGING_PROGRESS_FIRST_UPDATE_MS;
+    const comparisonVisibleAtMs = lastVisibleAtMs > 0 ? lastVisibleAtMs : startedAtMs;
+    const stalled = (now - lastVerifiedAtMs) >= MESSAGING_PROGRESS_STALL_MS;
+
+    if (stalled && !ledger.stallNotifiedAt) {
+      this.updateRunProgress(runId, {
+        stallNotifiedAt: isoNow(),
+        progressState: 'stalled',
+      });
+      this.recordRunEvent(runMeta.userId, runId, 'progress_stalled', {
+        currentTool: ledger.currentTool || null,
+        currentStep: ledger.currentStep || null,
+        phase: ledger.currentPhase || 'idle',
+      }, { agentId: runMeta.agentId });
+    }
+
+    if ((now - comparisonVisibleAtMs) < heartbeatThresholdMs) {
+      return { sent: false, skipped: true };
+    }
+
+    if (ledger.currentPhase === 'tool' && ledger.currentStepStartedAt) {
+      return this.sendRuntimeMessagingHeartbeat(runId, { stalled });
+    }
+
+    if (ledger.currentPhase !== 'idle') {
+      return { sent: false, skipped: true };
+    }
+
+    const lastSupervisorNudgeAtMs = timestampMs(runMeta.lastSupervisorNudgeAt, 0);
+    if (lastSupervisorNudgeAtMs > 0 && (now - lastSupervisorNudgeAtMs) < heartbeatThresholdMs) {
+      return { sent: false, skipped: true };
+    }
+
+    const nudge = stalled
+      ? 'The messaging user has only seen progress updates so far, and the run now appears stalled. Decide explicitly whether to continue, send one concise blocker update, or finish with the final answer. Do not leave the run with only an interim status.'
+      : 'The messaging user has not received a final answer yet. Decide explicitly whether to keep working, send one concise progress update, or finish with the final answer. Do not stop with only an interim status.';
+    const queued = this.enqueueSystemSteering(runId, nudge, {
+      reason: stalled ? 'stalled_progress_check' : 'progress_check',
+    });
+    if (!queued) {
+      return { sent: false, skipped: true };
+    }
+    runMeta.lastSupervisorNudgeAt = isoNow();
+    this.updateRunProgress(runId, {
+      lastUserVisibleUpdateAt: ledger.lastUserVisibleUpdateAt || null,
+    });
+    return { sent: false, queued: true };
+  }
+
+  startMessagingProgressSupervisor(runId) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta || runMeta.triggerSource !== 'messaging' || !runMeta.messagingContext?.platform || !runMeta.messagingContext?.chatId) {
+      return false;
+    }
+    if (runMeta.messagingProgressSupervisor?.timer) {
+      return true;
+    }
+    const timer = setInterval(() => {
+      this.tickMessagingProgressSupervisor(runId).catch((error) => {
+        console.warn('[Engine] Messaging progress supervisor failed:', error?.message || error);
+      });
+    }, MESSAGING_PROGRESS_TICK_MS);
+    timer.unref?.();
+    runMeta.messagingProgressSupervisor = { timer };
+    return true;
+  }
+
+  stopMessagingProgressSupervisor(runId) {
+    const runMeta = this.getRunMeta(runId);
+    const timer = runMeta?.messagingProgressSupervisor?.timer || null;
+    if (timer) {
+      clearInterval(timer);
+    }
+    if (runMeta?.messagingProgressSupervisor) {
+      runMeta.messagingProgressSupervisor = null;
+    }
   }
 
   isRunStopped(runId) {
@@ -1871,8 +2313,15 @@ class AgentEngine {
     );
 
     const retryMessagingState = options.messagingRetryState || {};
-    const carriedVisibleMessage = String(retryMessagingState.lastVisibleMessage || '').trim();
+    const carriedFinalMessage = String(retryMessagingState.lastFinalMessage || '').trim();
     const carriedExplicitMessageSent = retryMessagingState.explicitMessageSent === true;
+    const carriedInterimHistory = cloneInterimHistory(retryMessagingState.interimHistory);
+    const carriedLastInterimMessage = carriedInterimHistory[carriedInterimHistory.length - 1]?.content || '';
+    const startedAtIso = isoNow();
+    const progressLedger = buildInitialProgressLedger({
+      startedAt: startedAtIso,
+      retryState: retryMessagingState,
+    });
 
     this.activeRuns.set(runId, {
       userId,
@@ -1882,23 +2331,39 @@ class AgentEngine {
       messagingSent: false,
       noResponse: false,
       explicitMessageSent: carriedExplicitMessageSent,
-      lastSentMessage: carriedExplicitMessageSent ? carriedVisibleMessage : '',
+      finalDeliverySent: carriedExplicitMessageSent,
+      lastSentMessage: carriedExplicitMessageSent ? carriedFinalMessage : '',
       sentMessages: [],
       widgetSnapshotSaved: false,
       triggerType,
       triggerSource,
       startedAt: Date.now(),
+      startedAtIso,
       lastToolName: null,
       lastToolTarget: null,
-      lastInterimMessage: carriedExplicitMessageSent ? '' : carriedVisibleMessage,
-      interimMessages: [],
-      interimSignatures: new Set(),
+      lastInterimMessage: carriedExplicitMessageSent ? '' : carriedLastInterimMessage,
+      interimMessages: carriedExplicitMessageSent ? [] : carriedInterimHistory,
+      interimSignatures: carriedExplicitMessageSent
+        ? new Set()
+        : createInterimSignatureSet(carriedInterimHistory, options.source || null),
       terminalInterim: null,
       voiceSessionId: options.voiceSessionId || null,
       steeringQueue: [],
+      systemSteeringQueue: [],
       toolPids: new Set(),
       repetitionGuard: new ToolRepetitionGuard(),
+      messagingContext: triggerSource === 'messaging'
+        ? {
+          platform: options.source || null,
+          chatId: options.chatId || null,
+        }
+        : null,
+      progressLedger,
     });
+    this.persistRunMetadata(runId, {
+      progressLedger,
+    });
+    this.startMessagingProgressSupervisor(runId);
     this.emit(userId, 'run:start', { runId, agentId, title: runTitle, model, triggerType, triggerSource });
     this.recordRunEvent(userId, runId, 'run_started', {
       title: runTitle,
@@ -2278,12 +2743,22 @@ class AgentEngine {
         if (this.isRunStopped(runId)) break;
         iteration++;
 
+        const systemSteeringAtLoopStart = this.applyQueuedSystemSteering(runId, messages);
+        messages = systemSteeringAtLoopStart.messages;
         const steeringAtLoopStart = this.applyQueuedSteering(runId, messages, {
           userId,
           conversationId
         });
         messages = steeringAtLoopStart.messages;
         messages = sanitizeConversationMessages(messages);
+        this.updateRunProgress(runId, {
+          currentPhase: 'model',
+          currentStep: `model:${iteration}`,
+          currentTool: null,
+          currentStepStartedAt: isoNow(),
+        }, {
+          verified: true,
+        });
 
         let metrics = this.estimatePromptMetrics(messages, tools);
         const contextWindow = provider.getContextWindow(model);
@@ -2444,6 +2919,21 @@ class AgentEngine {
         }
 
         if (!response.toolCalls || response.toolCalls.length === 0) {
+          this.updateRunProgress(runId, {
+            currentPhase: 'idle',
+            currentStep: null,
+            currentTool: null,
+            currentStepStartedAt: null,
+          }, {
+            verified: true,
+          });
+          const systemSteeringAfterResponse = this.applyQueuedSystemSteering(runId, messages);
+          messages = systemSteeringAfterResponse.messages;
+          if (systemSteeringAfterResponse.appliedCount > 0) {
+            iteration = Math.max(0, iteration - 1);
+            lastContent = '';
+            continue;
+          }
           const steeringAfterResponse = this.applyQueuedSteering(runId, messages, {
             userId,
             conversationId
@@ -2470,11 +2960,13 @@ class AgentEngine {
               && this.activeRuns.get(runId)?.noResponse !== true
               && options.deliveryState?.noResponse !== true
             );
+            const visibleInterimActivity = hasVisibleInterimActivity(this.activeRuns.get(runId));
             const fallbackStatus = (
               proactiveRunNeedsDecision
               || toolExecutions.length > 0
               || failedStepCount > 0
               || messagingSent
+              || visibleInterimActivity
             ) ? 'continue' : 'complete';
             const loopState = await runWithModelFallback('loop decision', () => this.decideLoopState({
               provider,
@@ -2685,6 +3177,15 @@ class AgentEngine {
 
           db.prepare('INSERT INTO agent_steps (id, run_id, step_index, type, description, status, tool_name, tool_input, started_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime(\'now\'))')
             .run(stepId, runId, stepIndex, this.getStepType(toolName), `${toolName}: ${JSON.stringify(toolArgs).slice(0, 200)} `, 'running', toolName, JSON.stringify(toolArgs));
+          this.updateRunProgress(runId, {
+            currentPhase: 'tool',
+            currentStep: stepId,
+            currentTool: toolName,
+            currentStepStartedAt: isoNow(),
+          }, {
+            verified: true,
+            stepId,
+          });
 
           this.emit(userId, 'run:tool_start', {
             runId, stepId, stepIndex, toolName, toolArgs,
@@ -2885,6 +3386,16 @@ class AgentEngine {
               .run(conversationId, 'tool', toolMessage.content, toolCall.id, toolName);
           }
 
+          this.updateRunProgress(runId, {
+            currentPhase: 'idle',
+            currentStep: null,
+            currentTool: null,
+            currentStepStartedAt: null,
+          }, {
+            verified: true,
+            stepId,
+          });
+
           const runMeta = this.activeRuns.get(runId);
           if (runMeta) {
             runMeta.lastToolName = toolName;
@@ -2916,6 +3427,7 @@ class AgentEngine {
         console.warn(
           `[Run ${shortenRunId(runId)}] stopped trigger=${triggerSource} steps=${stepIndex} tokens=${totalTokens}`
         );
+        this.stopMessagingProgressSupervisor(runId);
         this.activeRuns.delete(runId);
         this.emit(userId, 'run:stopped', { runId, triggerSource });
         this.recordRunEvent(userId, runId, 'run_stopped', {
@@ -2991,9 +3503,8 @@ class AgentEngine {
       let finalResponseText = messagingSent
         ? (sentMessageText || (normalizedLastContent ? lastContent.trim() : ''))
         : (normalizedLastContent ? lastContent.trim() : sentMessageText);
-      const lastVisibleMessage = normalizeOutgoingMessage(
+      const lastFinalDeliveryMessage = normalizeOutgoingMessage(
         runMeta?.lastSentMessage
-        || runMeta?.lastInterimMessage
         || (Array.isArray(runMeta?.sentMessages) ? runMeta.sentMessages[runMeta.sentMessages.length - 1] : '')
         || '',
         options?.source || null
@@ -3130,39 +3641,19 @@ class AgentEngine {
         skipPersistence: options.skipRunContextPersistence === true
       });
 
-      // Fallback: if this was a messaging-triggered run and no user-visible
-      // message was already sent in this run, auto-send the final assistant text.
-      // After any visible reply already went out, later user-facing messages
-      // must be sent explicitly via send_message.
+      // Fallback: if this was a messaging-triggered run and no final delivery
+      // was already sent in this run, auto-send the final assistant text.
+      // Interim progress updates do not suppress this final delivery.
       if (triggerSource === 'messaging' && options.source && options.chatId) {
-        // Strip [NO RESPONSE] markers the AI may have embedded anywhere in the text,
-        // then only send if real content remains.
-        const cleanedContent = normalizeOutgoingMessage(lastContent || '', options.source, {
-          collapseWhitespace: false
-        });
-        const shouldSendFallback = (
-          cleanedContent
-          && runMeta?.explicitMessageSent !== true
-          && !lastVisibleMessage
-        );
-        if (shouldSendFallback) {
-          const manager = this.messagingManager;
-          if (manager) {
-            const chunks = splitOutgoingMessageForPlatform(options.source, cleanedContent);
-            console.info(
-              `[Run ${shortenRunId(runId)}] messaging_fallback chunks=${chunks.length} to=${summarizeForLog(options.chatId, 80)}`
-            );
-            for (let i = 0; i < chunks.length; i++) {
-              if (i > 0) {
-                const delay = Math.max(1000, Math.min(chunks[i].length * 30, 4000));
-                await manager.sendTyping(userId, options.source, options.chatId, true, { agentId }).catch(() => { });
-                await new Promise((resolve) => setTimeout(resolve, delay));
-              }
-              await manager.sendMessage(userId, options.source, options.chatId, chunks[i], { runId, agentId }).catch((err) =>
-                console.error('[Engine] Auto-reply fallback failed:', err.message)
-              );
-            }
-          }
+        if (this.shouldSendMessagingFinalFallback(runMeta, lastContent || '', options.source) && !lastFinalDeliveryMessage) {
+          await this.deliverMessagingFinalFallback({
+            runId,
+            userId,
+            agentId,
+            platform: options.source,
+            chatId: options.chatId,
+            content: lastContent || '',
+          });
         }
       }
 
@@ -3170,6 +3661,7 @@ class AgentEngine {
         `[Run ${shortenRunId(runId)}] completed trigger=${triggerSource} steps=${stepIndex} tokens=${totalTokens} durationMs=${runMeta?.startedAt ? Date.now() - runMeta.startedAt : 0} finalResponse=${finalResponseText ? 'yes' : 'no'} sentMessages=${runMeta?.sentMessages?.length || 0}`
       );
       this.cleanupSubagentsForRun(runId, { cancelRunning: true });
+      this.stopMessagingProgressSupervisor(runId);
       this.activeRuns.delete(runId);
       this.emit(userId, 'run:complete', {
         runId,
@@ -3230,6 +3722,7 @@ class AgentEngine {
           `[Run ${shortenRunId(runId)}] stopped trigger=${triggerSource} steps=${stepIndex} tokens=${totalTokens}`
         );
         this.cleanupSubagentsForRun(runId, { cancelRunning: true });
+        this.stopMessagingProgressSupervisor(runId);
         this.activeRuns.delete(runId);
         this.emit(userId, 'run:stopped', { runId, triggerSource });
         this.recordRunEvent(userId, runId, 'run_stopped', {
@@ -3267,18 +3760,13 @@ class AgentEngine {
             || runMeta?.messagingSent === true
           ),
         });
-        const lastVisibleMessage = normalizeOutgoingMessage(
-          runMeta?.lastSentMessage
-          || runMeta?.lastInterimMessage
-          || '',
-          options?.source || null
-        );
         db.prepare('UPDATE agent_runs SET status = ?, error = ?, updated_at = datetime(\'now\') WHERE id = ?')
           .run('retrying', err.message, runId);
         console.warn(
           `[Run ${shortenRunId(runId)}] retrying_messaging_attempt=${retryCount + 1} reason=${summarizeForLog(err.message, 140)}`
         );
         this.cleanupSubagentsForRun(runId, { cancelRunning: true });
+        this.stopMessagingProgressSupervisor(runId);
         this.activeRuns.delete(runId);
         this.emit(userId, 'run:interim', {
           runId,
@@ -3290,8 +3778,17 @@ class AgentEngine {
           ...options,
           messagingAutonomousRetryCount: retryCount + 1,
           messagingRetryState: {
-            lastVisibleMessage: lastVisibleMessage || String(options?.messagingRetryState?.lastVisibleMessage || '').trim(),
+            lastFinalMessage: String(runMeta?.lastSentMessage || options?.messagingRetryState?.lastFinalMessage || '').trim(),
             explicitMessageSent: runMeta?.explicitMessageSent === true || options?.messagingRetryState?.explicitMessageSent === true,
+            interimHistory: cloneInterimHistory([
+              ...(Array.isArray(options?.messagingRetryState?.interimHistory) ? options.messagingRetryState.interimHistory : []),
+              ...(Array.isArray(runMeta?.interimMessages) ? runMeta.interimMessages : []),
+            ]),
+            lastUserVisibleUpdateAt: runMeta?.progressLedger?.lastUserVisibleUpdateAt || options?.messagingRetryState?.lastUserVisibleUpdateAt || null,
+            lastFinalDeliveryAt: runMeta?.progressLedger?.lastFinalDeliveryAt || options?.messagingRetryState?.lastFinalDeliveryAt || null,
+            heartbeatCount: Number(runMeta?.progressLedger?.heartbeatCount || options?.messagingRetryState?.heartbeatCount || 0),
+            progressState: runMeta?.progressLedger?.progressState || options?.messagingRetryState?.progressState || 'active',
+            lastVerifiedProgressAt: runMeta?.progressLedger?.lastVerifiedProgressAt || options?.messagingRetryState?.lastVerifiedProgressAt || null,
           },
           context: {
             ...(options.context || {}),
@@ -3358,6 +3855,7 @@ class AgentEngine {
                 if (!Array.isArray(runMeta.sentMessages)) runMeta.sentMessages = [];
                 runMeta.sentMessages.push(messagingFailureContent);
               }
+              this.markRunFinalDelivery(runId, messagingFailureContent);
             } catch (sendErr) {
               console.error('[Engine] Messaging error fallback failed:', sendErr.message);
               messagingFailureContent = '';
@@ -3380,6 +3878,7 @@ class AgentEngine {
       );
 
       this.cleanupSubagentsForRun(runId, { cancelRunning: true });
+      this.stopMessagingProgressSupervisor(runId);
       this.activeRuns.delete(runId);
       this.emit(userId, 'run:error', { runId, error: err.message });
       this.recordRunEvent(userId, runId, 'run_failed', {

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -2228,7 +2228,7 @@ class AgentEngine {
     if (!runMeta || runMeta.aborted || runMeta.triggerSource !== 'messaging') {
       return { sent: false, skipped: true };
     }
-    if (runMeta.finalDeliverySent === true || runMeta.terminalInterim) {
+    if (runMeta.terminalInterim) {
       return { sent: false, skipped: true };
     }
 
@@ -2596,6 +2596,7 @@ class AgentEngine {
     this.activeRuns.set(runId, {
       userId,
       agentId,
+      title: runTitle,
       status: 'running',
       aborted: false,
       messagingSent: false,

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -144,6 +144,7 @@ function normalizeErrorKey(errorMsg) {
   if (/enoent|no such file/i.test(msg)) return 'enoent';
   if (/can.?t cd to|no such directory/i.test(msg)) return 'bad_cwd';
   if (/not found/i.test(msg)) return 'not_found';
+  if (/owner_repo.*format|must be.*owner.*repo|owner.*repo.*string|owner.*repo.*combined/i.test(msg)) return 'owner_repo_format';
   return msg.slice(0, 60);
 }
 
@@ -155,10 +156,20 @@ function trackErrorPattern(errorMsg, runMeta) {
 }
 
 function buildErrorPatternGuidance(key, count) {
+  // Immediate guidance on first occurrence for high-signal patterns that waste
+  // multiple iterations before self-correcting.
+  const immediateGuides = {
+    eisdir: 'That path is a directory (or a VM-only path like /tmp that read_file cannot reach). Use execute_command with `cat <path>` to read files inside VMs, or list_directory to inspect a directory.',
+    owner_repo_format: 'The parameter "owner_repo" expects a single combined string like "NeoLabs-Systems/NeoAgent" — not separate owner/repo fields. Pass the full "owner/repo" as one value.',
+  };
+  if (immediateGuides[key]) {
+    const prefix = count > 1 ? `REPEATED ERROR (${count}×): ` : 'ERROR GUIDANCE: ';
+    return `${prefix}${immediateGuides[key]}`;
+  }
+
   if (count < 3) return null;
   const guides = {
     outside_workspace: 'read_file cannot access /tmp paths. Use execute_command with `cat <path>` instead.',
-    eisdir: 'That path is a directory, not a file. Use list_directory or execute_command with `ls` to inspect it.',
     enoent: 'That path does not exist. Use execute_command with `find . -name "..."` to locate the correct path first.',
     bad_cwd: 'The VM home directory is not ~/. Use absolute paths starting from /tmp or discover the workspace root first.',
     not_found: 'This path or resource was not found. Try listing the parent directory or checking with a broader search first.',
@@ -166,6 +177,19 @@ function buildErrorPatternGuidance(key, count) {
   const guide = guides[key];
   if (!guide) return null;
   return `REPEATED ERROR (${count}×): ${guide}`;
+}
+
+const OUTPUT_FINGERPRINT_TOOLS = /^(list_|search_|read_|get_|find_|github_list|github_get|github_search)/;
+
+function fingerprintOutput(toolName, result) {
+  if (!toolName || !OUTPUT_FINGERPRINT_TOOLS.test(toolName)) return null;
+  const raw = typeof result === 'string' ? result : JSON.stringify(result ?? '');
+  if (raw.length < 200) return null;
+  // djb2 hash over first 3000 chars — fast, collision-unlikely for our sizes
+  let h = 5381;
+  const limit = Math.min(raw.length, 3000);
+  for (let i = 0; i < limit; i++) h = ((h << 5) + h) ^ raw.charCodeAt(i);
+  return h >>> 0;
 }
 
 function resolveModelCallTimeoutMs(options = {}) {
@@ -2623,6 +2647,7 @@ class AgentEngine {
       systemSteeringQueue: [],
       toolPids: new Set(),
       repetitionGuard: new ToolRepetitionGuard(),
+      seenOutputHashes: new Map(),
       messagingContext: triggerSource === 'messaging'
         ? {
           platform: options.source || null,
@@ -3010,6 +3035,13 @@ class AgentEngine {
         }, { agentId });
       }
       messages = sanitizeConversationMessages(messages);
+
+      if (analysis.mode === 'execute' || analysis.mode === 'plan_execute') {
+        messages.push({
+          role: 'system',
+          content: 'Research budget: after 3 read/list/search tool calls, you must take a concrete action (write, create, send, update) or explain clearly why you cannot. Work on one item at a time — do not queue up more reads.',
+        });
+      }
 
       directAnswerEligible = isDirectAnswerEligibleAnalysis(analysis)
         && Boolean(normalizeOutgoingMessage(analysis.draft_reply));
@@ -3595,6 +3627,22 @@ class AgentEngine {
             }
           } else {
             consecutiveToolFailures = 0;
+            // Output fingerprint guard: steer away from re-fetching data already seen.
+            if (!toolErrorMessage) {
+              const currentRunMeta = this.getRunMeta(runId);
+              const fp = fingerprintOutput(toolName, toolResult);
+              if (fp !== null && currentRunMeta?.seenOutputHashes) {
+                const prior = currentRunMeta.seenOutputHashes.get(fp);
+                if (prior) {
+                  messages.push({
+                    role: 'system',
+                    content: `DUPLICATE DATA: This response is identical to what "${prior.toolName}" returned in iteration ${prior.iteration}. You already have this information. Stop fetching and use what you have — proceed to the next concrete action.`,
+                  });
+                } else {
+                  currentRunMeta.seenOutputHashes.set(fp, { toolName, iteration });
+                }
+              }
+            }
           }
 
           if (toolName === 'send_interim_update') {

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -168,6 +168,13 @@ function buildErrorPatternGuidance(key, count) {
   return `REPEATED ERROR (${count}×): ${guide}`;
 }
 
+const DEFINITELY_MUTATING_PATTERN = /^(write_file|create_file|append_file|patch_file|delete_file|move_file|copy_file|send_message|send_interim_update|make_call|memory_save|memory_update|memory_delete|create_task|update_task|delete_task|task_complete|save_widget_snapshot|github_create_|github_update_|github_merge_|github_close_|github_delete_|github_push_|github_create_branch|github_delete_branch|github_create_commit|subagent_create|subagent_cancel|create_|write_|update_|delete_|send_|push_|commit_|publish_|deploy_)/;
+
+function isDefinitelyMutating(toolName) {
+  if (!toolName) return false;
+  return DEFINITELY_MUTATING_PATTERN.test(toolName);
+}
+
 function resolveModelCallTimeoutMs(options = {}) {
   const requested = Number(options?.modelCallTimeoutMs);
   if (Number.isFinite(requested) && requested > 0) {
@@ -3029,10 +3036,34 @@ class AgentEngine {
       // full run so the failure guard fires correctly after 5 consecutive failures
       // regardless of which iteration they fall in.
       let consecutiveToolFailures = 0;
+      let stagnantIterations = 0;
+      const MILESTONE_PCTS = [0.40, 0.65, 0.85];
+      const firedMilestones = new Set();
 
       while (!directAnswerEligible && iteration < maxIterations) {
         if (this.isRunStopped(runId)) break;
         iteration++;
+        let iterationHadMutatingTool = false;
+
+        // ── Iteration milestone steering ─────────────────────────────────────
+        // Warn the agent at 40/65/85 % of its budget so it stops exploring.
+        for (const pct of MILESTONE_PCTS) {
+          const threshold = Math.floor(maxIterations * pct);
+          if (iteration === threshold && !firedMilestones.has(pct)) {
+            firedMilestones.add(pct);
+            const remaining = maxIterations - iteration;
+            const pctLabel = Math.round(pct * 100);
+            let urgency;
+            if (pct >= 0.85) {
+              urgency = `CRITICAL: only ${remaining} turn(s) left. Wrap up immediately — call task_complete or send the final answer now.`;
+            } else if (pct >= 0.65) {
+              urgency = `Stop exploring. Take decisive action now: write code, send the answer, or call task_complete. ${remaining} turns remaining.`;
+            } else {
+              urgency = `${pctLabel}% of your turn budget used (${remaining} turns remaining). Start converging — avoid further research unless absolutely necessary.`;
+            }
+            this.enqueueSystemSteering(runId, urgency, { reason: `milestone_${pctLabel}pct` });
+          }
+        }
 
         const systemSteeringAtLoopStart = this.applyQueuedSystemSteering(runId, messages);
         messages = systemSteeringAtLoopStart.messages;
@@ -3328,6 +3359,27 @@ class AgentEngine {
           }, {
             verified: true,
           });
+          // Parallel batch is always read-only — counts as stagnant.
+          stagnantIterations++;
+          if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
+            stagnantIterations = 0;
+            console.warn(
+              `[Run ${shortenRunId(runId)}] stagnation detected (parallel batch) at iteration=${iteration} — injecting steering`
+            );
+            const stagnantMsg = `You have spent ${loopPolicy.maxStagnantIterations} consecutive turns making only read/observe calls without creating, writing, or sending anything concrete. Stop gathering information. In your very next turn, take direct action: write code, create a PR, update a file, or call task_complete if you are genuinely blocked. The user is waiting for real results, not more analysis.`;
+            this.enqueueSystemSteering(runId, stagnantMsg, { reason: 'stagnation_detected' });
+            const stagnantMetrics = this.estimatePromptMetrics(messages, tools);
+            const stagnantContextWindow = provider.getContextWindow(model);
+            if (stagnantMetrics.totalEstimatedTokens > stagnantContextWindow * 0.5) {
+              messages = await withModelCallTimeout(
+                compact(messages, provider, model, stagnantContextWindow),
+                options,
+                `Context compaction on stagnation at iteration ${iteration}`,
+              );
+              messages = sanitizeConversationMessages(messages);
+              this.emit(userId, 'run:compaction', { runId, iteration });
+            }
+          }
           continue;
         }
 
@@ -3646,6 +3698,10 @@ class AgentEngine {
             }
           }
 
+          if (!toolErrorMessage && isDefinitelyMutating(toolName)) {
+            iterationHadMutatingTool = true;
+          }
+
           if (toolName === 'save_widget_snapshot' && !toolErrorMessage) {
             lastContent = 'Widget snapshot updated.';
             break;
@@ -3653,6 +3709,35 @@ class AgentEngine {
 
           if (runMeta?.terminalInterim) {
             break;
+          }
+        }
+
+        // ── Stagnation detection ──────────────────────────────────────────────
+        // Parallel batches are always read-only; serial iterations count as
+        // stagnant when no definitely-mutating tool succeeded this turn.
+        if (iterationHadMutatingTool) {
+          stagnantIterations = 0;
+        } else {
+          stagnantIterations++;
+          if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
+            stagnantIterations = 0;
+            console.warn(
+              `[Run ${shortenRunId(runId)}] stagnation detected at iteration=${iteration} — injecting steering`
+            );
+            const stagnantMsg = `You have spent ${loopPolicy.maxStagnantIterations} consecutive turns making only read/observe calls without creating, writing, or sending anything concrete. Stop gathering information. In your very next turn, take direct action: write code, create a PR, update a file, or call task_complete if you are genuinely blocked. The user is waiting for real results, not more analysis.`;
+            this.enqueueSystemSteering(runId, stagnantMsg, { reason: 'stagnation_detected' });
+            // Also compact context if it is more than 50 % full, to clear the noise.
+            const metrics = this.estimatePromptMetrics(messages, tools);
+            const contextWindow = provider.getContextWindow(model);
+            if (metrics.totalEstimatedTokens > contextWindow * 0.5) {
+              messages = await withModelCallTimeout(
+                compact(messages, provider, model, contextWindow),
+                options,
+                `Context compaction on stagnation at iteration ${iteration}`,
+              );
+              messages = sanitizeConversationMessages(messages);
+              this.emit(userId, 'run:compaction', { runId, iteration });
+            }
           }
         }
 

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -3749,7 +3749,41 @@ class AgentEngine {
           );
         }
         if (iteration >= maxIterations) {
-          throw new Error(`Iteration limit reached before explicit completion after ${maxIterations} iterations.`);
+          // Grace call: budget exhausted but no content yet.
+          // Strip tools and ask the model to summarise what it accomplished.
+          // Mirrors the Hermes handle_max_iterations() pattern.
+          console.warn(`[Run ${shortenRunId(runId)}] iteration_limit runId=${shortenRunId(runId)} — making grace call`);
+          try {
+            const graceMessages = sanitizeConversationMessages([
+              ...messages,
+              {
+                role: 'user',
+                content: 'You have reached the maximum number of tool-calling iterations allowed. Please provide a final response summarising what you found and accomplished so far, without calling any more tools.',
+              },
+            ]);
+            const graceResponse = await withModelCallTimeout(
+              provider.chat(graceMessages, [], {
+                model,
+                reasoningEffort: this.getReasoningEffort(providerName, options),
+              }),
+              options,
+              `Grace call after ${maxIterations} iterations`,
+            );
+            totalTokens += graceResponse.usage?.totalTokens || 0;
+            lastContent = sanitizeModelOutput(graceResponse.content || '', { model });
+            if (lastContent) {
+              messages.push({ role: 'assistant', content: lastContent });
+              if (conversationId) {
+                db.prepare('INSERT INTO conversation_messages (conversation_id, role, content, tokens) VALUES (?, ?, ?, ?)')
+                  .run(conversationId, 'assistant', lastContent, graceResponse.usage?.totalTokens || 0);
+              }
+            }
+          } catch (graceErr) {
+            console.warn(`[Run ${shortenRunId(runId)}] grace call failed: ${graceErr?.message}`);
+          }
+          if (!normalizeOutgoingMessage(lastContent, options?.source || null)) {
+            throw new Error(`Iteration limit reached before explicit completion after ${maxIterations} iterations.`);
+          }
         }
         if (stepIndex > 0 && !lastToolWasMessaging) {
           throw new Error('Run ended without an explicit completion or blocker reply.');

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -168,16 +168,6 @@ function buildErrorPatternGuidance(key, count) {
   return `REPEATED ERROR (${count}×): ${guide}`;
 }
 
-// Tools that definitely produce real output and reset the stagnation counter.
-// Everything NOT matched is treated as read/observe — conservative in the right
-// direction (under-counting stagnation is safer than over-counting it).
-const DEFINITELY_MUTATING_PATTERN = /^(write_file|create_file|append_file|patch_file|delete_file|move_file|copy_file|send_message|send_interim_update|make_call|memory_save|memory_update|memory_delete|create_task|update_task|delete_task|task_complete|save_widget_snapshot|github_create_|github_update_|github_merge_|github_close_|github_delete_|github_push_|github_create_branch|github_delete_branch|github_create_commit|subagent_create|subagent_cancel|create_|write_|update_|delete_|send_|push_|commit_|publish_|deploy_)/;
-
-function isDefinitelyMutating(toolName) {
-  if (!toolName) return false;
-  return DEFINITELY_MUTATING_PATTERN.test(toolName);
-}
-
 function resolveModelCallTimeoutMs(options = {}) {
   const requested = Number(options?.modelCallTimeoutMs);
   if (Number.isFinite(requested) && requested > 0) {
@@ -3039,12 +3029,10 @@ class AgentEngine {
       // full run so the failure guard fires correctly after 5 consecutive failures
       // regardless of which iteration they fall in.
       let consecutiveToolFailures = 0;
-      let stagnantIterations = 0;
 
       while (!directAnswerEligible && iteration < maxIterations) {
         if (this.isRunStopped(runId)) break;
         iteration++;
-        let iterationHadMutatingTool = false;
 
         const systemSteeringAtLoopStart = this.applyQueuedSystemSteering(runId, messages);
         messages = systemSteeringAtLoopStart.messages;
@@ -3340,8 +3328,6 @@ class AgentEngine {
           }, {
             verified: true,
           });
-          // Parallel batch is always read-only — always counts as stagnant.
-          stagnantIterations++;
           continue;
         }
 
@@ -3660,10 +3646,6 @@ class AgentEngine {
             }
           }
 
-          if (!toolErrorMessage && isDefinitelyMutating(toolName)) {
-            iterationHadMutatingTool = true;
-          }
-
           if (toolName === 'save_widget_snapshot' && !toolErrorMessage) {
             lastContent = 'Widget snapshot updated.';
             break;
@@ -3671,35 +3653,6 @@ class AgentEngine {
 
           if (runMeta?.terminalInterim) {
             break;
-          }
-        }
-
-        // ── Stagnation detection ──────────────────────────────────────────────
-        if (iterationHadMutatingTool) {
-          stagnantIterations = 0;
-        } else {
-          stagnantIterations++;
-          if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
-            stagnantIterations = 0;
-            console.warn(
-              `[Run ${shortenRunId(runId)}] stagnation at iteration=${iteration} — steering + compaction`
-            );
-            this.enqueueSystemSteering(
-              runId,
-              `You have spent ${loopPolicy.maxStagnantIterations} consecutive turns making only read/observe calls without writing, creating, or sending anything. Stop gathering information and take direct action now.`,
-              { reason: 'stagnation' },
-            );
-            const stagnantMetrics = this.estimatePromptMetrics(messages, tools);
-            const stagnantCtxWindow = provider.getContextWindow(model);
-            if (stagnantMetrics.totalEstimatedTokens > stagnantCtxWindow * 0.5) {
-              messages = await withModelCallTimeout(
-                compact(messages, provider, model, stagnantCtxWindow),
-                options,
-                `Context compaction on stagnation at iteration ${iteration}`,
-              );
-              messages = sanitizeConversationMessages(messages);
-              this.emit(userId, 'run:compaction', { runId, iteration });
-            }
           }
         }
 

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -3037,33 +3037,11 @@ class AgentEngine {
       // regardless of which iteration they fall in.
       let consecutiveToolFailures = 0;
       let stagnantIterations = 0;
-      const MILESTONE_PCTS = [0.40, 0.65, 0.85];
-      const firedMilestones = new Set();
 
       while (!directAnswerEligible && iteration < maxIterations) {
         if (this.isRunStopped(runId)) break;
         iteration++;
         let iterationHadMutatingTool = false;
-
-        // ── Iteration milestone steering ─────────────────────────────────────
-        // Warn the agent at 40/65/85 % of its budget so it stops exploring.
-        for (const pct of MILESTONE_PCTS) {
-          const threshold = Math.floor(maxIterations * pct);
-          if (iteration === threshold && !firedMilestones.has(pct)) {
-            firedMilestones.add(pct);
-            const remaining = maxIterations - iteration;
-            const pctLabel = Math.round(pct * 100);
-            let urgency;
-            if (pct >= 0.85) {
-              urgency = `CRITICAL: only ${remaining} turn(s) left. Wrap up immediately — call task_complete or send the final answer now.`;
-            } else if (pct >= 0.65) {
-              urgency = `Stop exploring. Take decisive action now: write code, send the answer, or call task_complete. ${remaining} turns remaining.`;
-            } else {
-              urgency = `${pctLabel}% of your turn budget used (${remaining} turns remaining). Start converging — avoid further research unless absolutely necessary.`;
-            }
-            this.enqueueSystemSteering(runId, urgency, { reason: `milestone_${pctLabel}pct` });
-          }
-        }
 
         const systemSteeringAtLoopStart = this.applyQueuedSystemSteering(runId, messages);
         messages = systemSteeringAtLoopStart.messages;
@@ -3364,10 +3342,8 @@ class AgentEngine {
           if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
             stagnantIterations = 0;
             console.warn(
-              `[Run ${shortenRunId(runId)}] stagnation detected (parallel batch) at iteration=${iteration} — injecting steering`
+              `[Run ${shortenRunId(runId)}] stagnation detected (parallel batch) at iteration=${iteration} — compacting context`
             );
-            const stagnantMsg = `You have spent ${loopPolicy.maxStagnantIterations} consecutive turns making only read/observe calls without creating, writing, or sending anything concrete. Stop gathering information. In your very next turn, take direct action: write code, create a PR, update a file, or call task_complete if you are genuinely blocked. The user is waiting for real results, not more analysis.`;
-            this.enqueueSystemSteering(runId, stagnantMsg, { reason: 'stagnation_detected' });
             const stagnantMetrics = this.estimatePromptMetrics(messages, tools);
             const stagnantContextWindow = provider.getContextWindow(model);
             if (stagnantMetrics.totalEstimatedTokens > stagnantContextWindow * 0.5) {
@@ -3722,11 +3698,8 @@ class AgentEngine {
           if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
             stagnantIterations = 0;
             console.warn(
-              `[Run ${shortenRunId(runId)}] stagnation detected at iteration=${iteration} — injecting steering`
+              `[Run ${shortenRunId(runId)}] stagnation detected at iteration=${iteration} — compacting context`
             );
-            const stagnantMsg = `You have spent ${loopPolicy.maxStagnantIterations} consecutive turns making only read/observe calls without creating, writing, or sending anything concrete. Stop gathering information. In your very next turn, take direct action: write code, create a PR, update a file, or call task_complete if you are genuinely blocked. The user is waiting for real results, not more analysis.`;
-            this.enqueueSystemSteering(runId, stagnantMsg, { reason: 'stagnation_detected' });
-            // Also compact context if it is more than 50 % full, to clear the noise.
             const metrics = this.estimatePromptMetrics(messages, tools);
             const contextWindow = provider.getContextWindow(model);
             if (metrics.totalEstimatedTokens > contextWindow * 0.5) {

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -168,13 +168,6 @@ function buildErrorPatternGuidance(key, count) {
   return `REPEATED ERROR (${count}×): ${guide}`;
 }
 
-const DEFINITELY_MUTATING_PATTERN = /^(write_file|create_file|append_file|patch_file|delete_file|move_file|copy_file|send_message|send_interim_update|make_call|memory_save|memory_update|memory_delete|create_task|update_task|delete_task|task_complete|save_widget_snapshot|github_create_|github_update_|github_merge_|github_close_|github_delete_|github_push_|github_create_branch|github_delete_branch|github_create_commit|subagent_create|subagent_cancel|create_|write_|update_|delete_|send_|push_|commit_|publish_|deploy_)/;
-
-function isDefinitelyMutating(toolName) {
-  if (!toolName) return false;
-  return DEFINITELY_MUTATING_PATTERN.test(toolName);
-}
-
 function resolveModelCallTimeoutMs(options = {}) {
   const requested = Number(options?.modelCallTimeoutMs);
   if (Number.isFinite(requested) && requested > 0) {
@@ -3036,12 +3029,10 @@ class AgentEngine {
       // full run so the failure guard fires correctly after 5 consecutive failures
       // regardless of which iteration they fall in.
       let consecutiveToolFailures = 0;
-      let stagnantIterations = 0;
 
       while (!directAnswerEligible && iteration < maxIterations) {
         if (this.isRunStopped(runId)) break;
         iteration++;
-        let iterationHadMutatingTool = false;
 
         const systemSteeringAtLoopStart = this.applyQueuedSystemSteering(runId, messages);
         messages = systemSteeringAtLoopStart.messages;
@@ -3337,25 +3328,6 @@ class AgentEngine {
           }, {
             verified: true,
           });
-          // Parallel batch is always read-only — counts as stagnant.
-          stagnantIterations++;
-          if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
-            stagnantIterations = 0;
-            console.warn(
-              `[Run ${shortenRunId(runId)}] stagnation detected (parallel batch) at iteration=${iteration} — compacting context`
-            );
-            const stagnantMetrics = this.estimatePromptMetrics(messages, tools);
-            const stagnantContextWindow = provider.getContextWindow(model);
-            if (stagnantMetrics.totalEstimatedTokens > stagnantContextWindow * 0.5) {
-              messages = await withModelCallTimeout(
-                compact(messages, provider, model, stagnantContextWindow),
-                options,
-                `Context compaction on stagnation at iteration ${iteration}`,
-              );
-              messages = sanitizeConversationMessages(messages);
-              this.emit(userId, 'run:compaction', { runId, iteration });
-            }
-          }
           continue;
         }
 
@@ -3674,10 +3646,6 @@ class AgentEngine {
             }
           }
 
-          if (!toolErrorMessage && isDefinitelyMutating(toolName)) {
-            iterationHadMutatingTool = true;
-          }
-
           if (toolName === 'save_widget_snapshot' && !toolErrorMessage) {
             lastContent = 'Widget snapshot updated.';
             break;
@@ -3685,32 +3653,6 @@ class AgentEngine {
 
           if (runMeta?.terminalInterim) {
             break;
-          }
-        }
-
-        // ── Stagnation detection ──────────────────────────────────────────────
-        // Parallel batches are always read-only; serial iterations count as
-        // stagnant when no definitely-mutating tool succeeded this turn.
-        if (iterationHadMutatingTool) {
-          stagnantIterations = 0;
-        } else {
-          stagnantIterations++;
-          if (stagnantIterations >= loopPolicy.maxStagnantIterations) {
-            stagnantIterations = 0;
-            console.warn(
-              `[Run ${shortenRunId(runId)}] stagnation detected at iteration=${iteration} — compacting context`
-            );
-            const metrics = this.estimatePromptMetrics(messages, tools);
-            const contextWindow = provider.getContextWindow(model);
-            if (metrics.totalEstimatedTokens > contextWindow * 0.5) {
-              messages = await withModelCallTimeout(
-                compact(messages, provider, model, contextWindow),
-                options,
-                `Context compaction on stagnation at iteration ${iteration}`,
-              );
-              messages = sanitizeConversationMessages(messages);
-              this.emit(userId, 'run:compaction', { runId, iteration });
-            }
           }
         }
 

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -116,6 +116,7 @@ const MESSAGING_PROGRESS_FIRST_UPDATE_MS = 60 * 1000;
 const MESSAGING_PROGRESS_REPEAT_MS = 90 * 1000;
 const MESSAGING_PROGRESS_STALL_MS = 240 * 1000;
 const MESSAGING_PROGRESS_TICK_MS = 15 * 1000;
+const GOAL_CONTRACT_SUCCESS_CRITERIA_LIMIT = 12;
 
 function isoNow() {
   return new Date().toISOString();
@@ -183,6 +184,302 @@ function hasVisibleInterimActivity(runMeta) {
     runMeta?.lastInterimMessage
     || (Array.isArray(runMeta?.interimMessages) && runMeta.interimMessages.length > 0)
     || Number(runMeta?.progressLedger?.heartbeatCount || 0) > 0
+  );
+}
+
+function normalizeGoalCriteria(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  const items = [];
+  for (const entry of value) {
+    const text = String(entry || '').trim();
+    if (!text) continue;
+    const signature = text.toLowerCase();
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    items.push(text);
+    if (items.length >= GOAL_CONTRACT_SUCCESS_CRITERIA_LIMIT) break;
+  }
+  return items;
+}
+
+function normalizeGoalContract(raw = null) {
+  if (!raw || typeof raw !== 'object') return null;
+  const goal = String(raw.goal || '').trim();
+  const successCriteria = normalizeGoalCriteria(
+    raw.successCriteria || raw.success_criteria || [],
+  );
+  const rawCompletionConfidence = String(
+    raw.completionConfidenceRequired || raw.completion_confidence_required || '',
+  ).trim();
+  const completionConfidenceRequired = rawCompletionConfidence
+    ? normalizeCompletionConfidence(rawCompletionConfidence)
+    : '';
+  const progressUpdatePolicy = ['none', 'optional', 'required'].includes(String(
+    raw.progressUpdatePolicy || raw.progress_update_policy || '',
+  ).trim().toLowerCase())
+    ? String(raw.progressUpdatePolicy || raw.progress_update_policy || '').trim().toLowerCase()
+    : '';
+  const autonomyLevel = ['minimal', 'normal', 'high'].includes(String(
+    raw.autonomyLevel || raw.autonomy_level || '',
+  ).trim().toLowerCase())
+    ? String(raw.autonomyLevel || raw.autonomy_level || '').trim().toLowerCase()
+    : '';
+  const complexity = ['simple', 'standard', 'complex'].includes(String(
+    raw.complexity || '',
+  ).trim().toLowerCase())
+    ? String(raw.complexity || '').trim().toLowerCase()
+    : '';
+
+  if (
+    !goal
+    && successCriteria.length === 0
+    && !completionConfidenceRequired
+    && !progressUpdatePolicy
+    && !autonomyLevel
+    && !complexity
+  ) {
+    return null;
+  }
+
+  return {
+    goal,
+    successCriteria,
+    completionConfidenceRequired,
+    progressUpdatePolicy: progressUpdatePolicy || '',
+    autonomyLevel: autonomyLevel || '',
+    complexity: complexity || '',
+  };
+}
+
+function mergeGoalContracts(existing = null, patch = null) {
+  const current = normalizeGoalContract(existing) || null;
+  const nextPatch = normalizeGoalContract(patch) || null;
+  if (!current && !nextPatch) return null;
+
+  const goal = String(nextPatch?.goal || current?.goal || '').trim();
+  const successCriteria = normalizeGoalCriteria([
+    ...(current?.successCriteria || []),
+    ...(nextPatch?.successCriteria || []),
+  ]);
+  const completionConfidenceRequired = nextPatch?.completionConfidenceRequired
+    || current?.completionConfidenceRequired
+    || 'medium';
+  const progressUpdatePolicy = nextPatch?.progressUpdatePolicy
+    || current?.progressUpdatePolicy
+    || '';
+  const autonomyLevel = nextPatch?.autonomyLevel
+    || current?.autonomyLevel
+    || '';
+  const complexity = nextPatch?.complexity
+    || current?.complexity
+    || '';
+
+  return normalizeGoalContract({
+    goal,
+    successCriteria,
+    completionConfidenceRequired,
+    progressUpdatePolicy,
+    autonomyLevel,
+    complexity,
+  });
+}
+
+function goalContractFromAnalysis(analysis = null) {
+  if (!analysis || typeof analysis !== 'object') return null;
+  return normalizeGoalContract({
+    goal: analysis.goal,
+    successCriteria: analysis.success_criteria,
+    completionConfidenceRequired: analysis.completion_confidence_required,
+    progressUpdatePolicy: analysis.progress_update_policy,
+    autonomyLevel: analysis.autonomy_level,
+    complexity: analysis.complexity,
+  });
+}
+
+function goalContractFromPlan(plan = null) {
+  if (!plan || typeof plan !== 'object') return null;
+  return normalizeGoalContract({
+    successCriteria: plan.success_criteria,
+  });
+}
+
+function buildResolvedGoalContract(runMeta, analysis = null, plan = null) {
+  let contract = mergeGoalContracts(runMeta?.goalContract || null, goalContractFromAnalysis(analysis));
+  contract = mergeGoalContracts(contract, goalContractFromPlan(plan));
+  return contract;
+}
+
+function buildGoalContractPrompt(contract, label = 'Persistent run goal') {
+  const normalized = normalizeGoalContract(contract);
+  if (!normalized) return '';
+  const lines = [];
+  if (normalized.goal) {
+    lines.push(`${label}: ${normalized.goal}`);
+  }
+  if (normalized.successCriteria.length > 0) {
+    lines.push(`Persistent success criteria:\n- ${normalized.successCriteria.join('\n- ')}`);
+  }
+  const contractLine = [
+    normalized.complexity ? `complexity=${normalized.complexity}` : '',
+    normalized.autonomyLevel ? `autonomy_level=${normalized.autonomyLevel}` : '',
+    normalized.progressUpdatePolicy ? `progress_update_policy=${normalized.progressUpdatePolicy}` : '',
+    normalized.completionConfidenceRequired ? `completion_confidence_required=${normalized.completionConfidenceRequired}` : '',
+  ].filter(Boolean).join('; ');
+  if (contractLine) {
+    lines.push(`Persistent autonomy contract: ${contractLine}`);
+  }
+  return lines.join('\n');
+}
+
+function resolveRunGoalContext(runMeta, analysis = null, plan = null) {
+  const goalContract = buildResolvedGoalContract(runMeta, analysis, plan);
+  const successCriteria = goalContract?.successCriteria?.length
+    ? goalContract.successCriteria.slice(0, 6)
+    : (Array.isArray(plan?.success_criteria)
+      ? plan.success_criteria
+        .map((item) => String(item || '').trim())
+        .filter(Boolean)
+        .slice(0, 6)
+      : []);
+  const effectiveGoal = goalContract?.goal || analysis?.goal || '';
+  const effectiveComplexity = goalContract?.complexity || analysis?.complexity || 'standard';
+  const effectiveAutonomyLevel = goalContract?.autonomyLevel || analysis?.autonomy_level || 'normal';
+  const effectiveProgressPolicy = goalContract?.progressUpdatePolicy || analysis?.progress_update_policy || 'optional';
+  const effectiveCompletionConfidence = goalContract?.completionConfidenceRequired
+    || analysis?.completion_confidence_required
+    || 'medium';
+  const persistedGoalPrompt = buildGoalContractPrompt(goalContract);
+  return {
+    goalContract,
+    successCriteria,
+    effectiveGoal,
+    effectiveComplexity,
+    effectiveAutonomyLevel,
+    effectiveProgressPolicy,
+    effectiveCompletionConfidence,
+    persistedGoalPrompt,
+  };
+}
+
+function buildCompletionDecisionPrompt({
+  mode,
+  triggerSource,
+  messagingSent = false,
+  goalContext,
+  parallelWork = false,
+  tools,
+  toolExecutions,
+  lastReply,
+  iteration,
+  maxIterations,
+  progressSummary = '',
+  platform = null,
+}) {
+  const draftReply = mode === 'messaging'
+    ? (normalizeOutgoingMessage(lastReply || '', platform, { collapseWhitespace: false })
+      ? String(lastReply || '').trim()
+      : '')
+    : normalizeOutgoingMessage(lastReply) || '';
+  const lines = [
+    'Return JSON only.',
+  ];
+
+  if (mode === 'messaging') {
+    lines.push(
+      'A messaging run is about to stop after sending user-visible progress, but no final delivery has happened yet.',
+      'Decide whether the run should keep working, finish with the completed result now, or stop with one blocker reply now.',
+      'Schema: {"status":"continue|complete|blocked","reason":"short concrete reason","final_reply":"string"}',
+      'Rules:',
+      '- Use "continue" whenever any safe next step remains in this same run.',
+      '- Use "complete" only when the requested outcome is actually achieved and final_reply is the finished user-facing answer to send now.',
+      '- Use "blocked" only when a specific external dependency, missing user input, or permission outside this run is required and final_reply is the concise blocker reply to send now.',
+      '- A progress note, next-step note, apology, plan, or "I will investigate" draft is "continue", not "complete" and not "blocked".',
+      '- If user-visible progress was already sent and no final delivery exists yet, do not stop silently and do not stop on a status-only draft.',
+      '- final_reply must be empty when status is "continue".',
+    );
+  } else {
+    lines.push(
+      'Decide whether this run should continue autonomously or stop now.',
+      'Schema: {"status":"continue|complete|blocked","reason":"short concrete reason"}',
+      'Rules:',
+      '- Use "continue" whenever any safe next step remains in this same run.',
+      '- Use "complete" only when the requested outcome is actually achieved or a truthful final user reply is already ready now.',
+      '- Use "blocked" only when a specific external dependency outside this run is required.',
+      '- If the latest draft asks the user for a missing required value, confirmation, or choice needed to proceed, use "blocked" so the run waits instead of repeating the same ask.',
+      '- A progress update is not complete.',
+      '- A single failed tool attempt is not blocked if another safe retry, verification step, or alternative path remains.',
+      '- A tool-specific API error, timeout, rate limit, or missing result inside this run is usually "continue", not "blocked", if any other available tool could still make progress.',
+      `- If completion_confidence_required is ${goalContext.effectiveCompletionConfidence} and the latest draft depends on unverified assumptions, use "continue" so the run can gather evidence, inspect state, or narrow the reply.`,
+      triggerSource === 'messaging' && messagingSent
+        ? '- A reply was already delivered to the user via send_message. Use "complete" unless there is concrete remaining work (e.g., a tool call you still need to make) before the task is truly done. Do not send follow-up elaborations or re-introductions.'
+        : triggerSource === 'messaging'
+          ? '- For messaging, do not stop on a partial status message. Continue unless the task is actually complete or externally blocked. If you already asked for missing user input, choose "blocked" and wait.'
+          : '- Do not stop just because you wrote a status update. Continue unless the task is actually complete or externally blocked.',
+    );
+  }
+
+  lines.push(
+    goalContext.effectiveGoal ? `Goal: ${goalContext.effectiveGoal}` : '',
+    goalContext.persistedGoalPrompt,
+    `Autonomy contract: complexity=${goalContext.effectiveComplexity}; autonomy_level=${goalContext.effectiveAutonomyLevel}; progress_update_policy=${goalContext.effectiveProgressPolicy}; parallel_work=${parallelWork === true}; completion_confidence_required=${goalContext.effectiveCompletionConfidence}.`,
+    goalContext.successCriteria.length > 0
+      ? `Success criteria:\n${goalContext.successCriteria.map((item, index) => `${index + 1}. ${item}`).join('\n')}`
+      : '',
+    `Current iteration: ${iteration} of ${maxIterations}.`,
+    `Available tools in this run: ${summarizeAvailableTools(tools) || 'none'}`,
+    mode === 'messaging' && progressSummary ? `Progress ledger: ${progressSummary}` : '',
+    `Recent tool evidence:\n${summarizeToolExecutions(toolExecutions, 8) || 'none'}`,
+    `Latest draft reply:\n${draftReply || '(empty)'}`,
+    mode === 'messaging' ? buildPlatformFormattingGuide(platform) : '',
+  );
+  return lines.filter(Boolean).join('\n');
+}
+
+function normalizeCompletionDecision(raw, {
+  mode,
+  fallbackStatus = 'continue',
+  platform = null,
+  draftReply = '',
+}) {
+  const allowed = new Set(['continue', 'complete', 'blocked']);
+  if (mode === 'messaging') {
+    let status = allowed.has(String(raw.status || '').trim().toLowerCase())
+      ? String(raw.status || '').trim().toLowerCase()
+      : 'continue';
+    let finalReply = normalizeOutgoingMessage(raw.final_reply || '', platform, {
+      collapseWhitespace: false,
+    })
+      ? String(raw.final_reply || '').trim()
+      : '';
+    if (status === 'continue') {
+      finalReply = '';
+    } else if (!finalReply && draftReply) {
+      finalReply = draftReply;
+    } else if (!finalReply) {
+      status = 'continue';
+    }
+    return {
+      status,
+      reason: String(raw.reason || '').trim().slice(0, 400),
+      final_reply: finalReply,
+    };
+  }
+
+  const requestedStatus = String(raw.status || '').trim().toLowerCase();
+  return {
+    status: allowed.has(requestedStatus) ? requestedStatus : fallbackStatus,
+    reason: String(raw.reason || '').trim().slice(0, 400),
+  };
+}
+
+function shouldRequireMessagingFinalityCheck(runMeta) {
+  return Boolean(
+    runMeta
+    && runMeta.triggerSource === 'messaging'
+    && runMeta.finalDeliverySent !== true
+    && !runMeta.terminalInterim
+    && hasVisibleInterimActivity(runMeta)
   );
 }
 
@@ -627,6 +924,33 @@ class AgentEngine {
     const next = { ...current, ...patch };
     db.prepare('UPDATE agent_runs SET metadata_json = ? WHERE id = ?')
       .run(JSON.stringify(next), runId);
+  }
+
+  replaceLatestConversationAssistantMessage(conversationId, content) {
+    if (!conversationId) return false;
+    const messageId = db.prepare(
+      `SELECT id
+       FROM conversation_messages
+       WHERE conversation_id = ? AND role = 'assistant'
+       ORDER BY id DESC
+       LIMIT 1`
+    ).get(conversationId)?.id;
+    if (!messageId) return false;
+    db.prepare('UPDATE conversation_messages SET content = ? WHERE id = ?')
+      .run(content, messageId);
+    return true;
+  }
+
+  updateRunGoalContract(runId, patch = {}, options = {}) {
+    const runMeta = this.getRunMeta(runId);
+    if (!runMeta) return null;
+    runMeta.goalContract = mergeGoalContracts(runMeta.goalContract, patch);
+    if (options.persist !== false) {
+      this.persistRunMetadata(runId, {
+        goalContract: runMeta.goalContract,
+      });
+    }
+    return runMeta.goalContract;
   }
 
   buildProgressLedgerSnapshot(runMeta) {
@@ -1152,53 +1476,31 @@ class AgentEngine {
     options,
     fallbackStatus,
   }) {
-    const successCriteria = Array.isArray(plan?.success_criteria)
-      ? plan.success_criteria
-        .map((item) => String(item || '').trim())
-        .filter(Boolean)
-        .slice(0, 6)
-      : [];
+    const runMeta = options?.runId ? this.getRunMeta(options.runId) : null;
+    const goalContext = resolveRunGoalContext(runMeta, analysis, plan);
 
     const response = await this.requestStructuredJson({
       provider,
       providerName,
       model,
       messages,
-      prompt: [
-        'Return JSON only.',
-        'Decide whether this run should continue autonomously or stop now.',
-        'Schema: {"status":"continue|complete|blocked","reason":"short concrete reason"}',
-        'Rules:',
-        '- Use "continue" whenever any safe next step remains in this same run.',
-        '- Use "complete" only when the requested outcome is actually achieved or a truthful final user reply is already ready now.',
-        '- Use "blocked" only when a specific external dependency outside this run is required.',
-        '- If the latest draft asks the user for a missing required value, confirmation, or choice needed to proceed, use "blocked" so the run waits instead of repeating the same ask.',
-        '- A progress update is not complete.',
-        '- A single failed tool attempt is not blocked if another safe retry, verification step, or alternative path remains.',
-        '- A tool-specific API error, timeout, rate limit, or missing result inside this run is usually "continue", not "blocked", if any other available tool could still make progress.',
-        '- If completion_confidence_required is high and the latest draft depends on unverified assumptions, use "continue" so the run can gather evidence, inspect state, or narrow the reply.',
-        triggerSource === 'messaging' && messagingSent
-          ? '- A reply was already delivered to the user via send_message. Use "complete" unless there is concrete remaining work (e.g., a tool call you still need to make) before the task is truly done. Do not send follow-up elaborations or re-introductions.'
-          : triggerSource === 'messaging'
-            ? '- For messaging, do not stop on a partial status message. Continue unless the task is actually complete or externally blocked. If you already asked for missing user input, choose "blocked" and wait.'
-            : '- Do not stop just because you wrote a status update. Continue unless the task is actually complete or externally blocked.',
-        analysis?.goal ? `Goal: ${analysis.goal}` : '',
-        `Autonomy contract: complexity=${analysis?.complexity || 'standard'}; autonomy_level=${analysis?.autonomy_level || 'normal'}; progress_update_policy=${analysis?.progress_update_policy || 'optional'}; parallel_work=${analysis?.parallel_work === true}; completion_confidence_required=${analysis?.completion_confidence_required || 'medium'}.`,
-        successCriteria.length > 0 ? `Success criteria:\n${successCriteria.map((item, index) => `${index + 1}. ${item}`).join('\n')}` : '',
-        `Current iteration: ${iteration} of ${maxIterations}.`,
-        `Available tools in this run: ${summarizeAvailableTools(tools) || 'none'}`,
-        `Recent tool evidence:\n${summarizeToolExecutions(toolExecutions, 8) || 'none'}`,
-        `Latest draft reply:\n${normalizeOutgoingMessage(lastReply) || '(empty)'}`,
-      ].filter(Boolean).join('\n'),
+      prompt: buildCompletionDecisionPrompt({
+        mode: 'loop',
+        triggerSource,
+        messagingSent,
+        goalContext,
+        parallelWork: analysis?.parallel_work === true,
+        tools,
+        toolExecutions,
+        lastReply,
+        iteration,
+        maxIterations,
+      }),
       maxTokens: 320,
-      normalize: (raw) => {
-        const allowed = new Set(['continue', 'complete', 'blocked']);
-        const requestedStatus = String(raw.status || '').trim().toLowerCase();
-        return {
-          status: allowed.has(requestedStatus) ? requestedStatus : fallbackStatus,
-          reason: String(raw.reason || '').trim().slice(0, 400),
-        };
-      },
+      normalize: (raw) => normalizeCompletionDecision(raw, {
+        mode: 'loop',
+        fallbackStatus,
+      }),
       fallback: { status: fallbackStatus },
       reasoningEffort: this.getReasoningEffort(providerName, options),
       telemetry: options,
@@ -1825,23 +2127,192 @@ class AgentEngine {
     return { messages, appliedCount: queued.length };
   }
 
+  async decideMessagingCompletionState({
+    provider,
+    providerName,
+    model,
+    messages,
+    analysis,
+    plan,
+    tools,
+    toolExecutions,
+    lastReply,
+    iteration,
+    maxIterations,
+    runId,
+    options,
+  }) {
+    const runMeta = this.getRunMeta(runId);
+    const goalContext = resolveRunGoalContext(runMeta, analysis, plan);
+    const platform = options?.source || null;
+    const normalizedDraft = normalizeOutgoingMessage(lastReply || '', platform, {
+      collapseWhitespace: false,
+    });
+    const draftReply = normalizedDraft ? String(lastReply || '').trim() : '';
+    const ledger = runMeta?.progressLedger || null;
+    const progressSummary = [
+      `progress_state=${ledger?.progressState || 'active'}`,
+      `current_phase=${ledger?.currentPhase || 'idle'}`,
+      `current_tool=${ledger?.currentTool || 'none'}`,
+      `heartbeat_count=${Number(ledger?.heartbeatCount || 0)}`,
+      `last_visible_update=${ledger?.lastUserVisibleUpdateAt || 'none'}`,
+      `last_verified_progress=${ledger?.lastVerifiedProgressAt || 'none'}`,
+      `last_final_delivery=${ledger?.lastFinalDeliveryAt || 'none'}`,
+    ].join('; ');
+
+    const response = await this.requestStructuredJson({
+      provider,
+      providerName,
+      model,
+      messages,
+      prompt: buildCompletionDecisionPrompt({
+        mode: 'messaging',
+        goalContext,
+        parallelWork: analysis?.parallel_work === true,
+        tools,
+        toolExecutions,
+        lastReply: draftReply,
+        iteration,
+        maxIterations,
+        progressSummary,
+        platform,
+      }),
+      maxTokens: 480,
+      normalize: (raw) => normalizeCompletionDecision(raw, {
+        mode: 'messaging',
+        platform,
+        draftReply,
+      }),
+      fallback: {
+        status: 'continue',
+        reason: '',
+        final_reply: '',
+      },
+      reasoningEffort: this.getReasoningEffort(providerName, options),
+      telemetry: options,
+      phase: 'messaging_completion',
+    });
+
+    return {
+      decision: response.value,
+      usage: response.usage,
+    };
+  }
+
+  async resolveMessagingCompletionDecision({
+    provider,
+    providerName,
+    model,
+    messages,
+    analysis,
+    plan,
+    tools,
+    toolExecutions,
+    lastReply,
+    iteration,
+    maxIterations,
+    runId,
+    conversationId,
+    options,
+  }) {
+    const runMeta = this.getRunMeta(runId);
+    if (!shouldRequireMessagingFinalityCheck(runMeta)) {
+      return {
+        action: 'none',
+        content: lastReply,
+        reason: '',
+        usage: 0,
+      };
+    }
+
+    let completionDecision;
+    try {
+      completionDecision = await this.decideMessagingCompletionState({
+        provider,
+        providerName,
+        model,
+        messages,
+        analysis,
+        plan,
+        tools,
+        toolExecutions,
+        lastReply,
+        iteration,
+        maxIterations,
+        runId,
+        options,
+      });
+    } catch (error) {
+      if (iteration >= maxIterations) {
+        const wrapped = new Error(
+          `Messaging completion check failed after visible progress: ${error?.message || error}`,
+        );
+        wrapped.disableAutonomousRetry = error?.disableAutonomousRetry === true;
+        throw wrapped;
+      }
+      return {
+        action: 'continue',
+        content: '',
+        reason: 'The run still needs an explicit final result or blocker decision.',
+        usage: 0,
+      };
+    }
+
+    const decision = completionDecision.decision || { status: 'continue', reason: '' };
+    if (decision.status === 'continue') {
+      if (iteration >= maxIterations) {
+        throw new Error(
+          'Messaging run reached the iteration limit before producing a final answer or blocker after visible progress.',
+        );
+      }
+      return {
+        action: 'continue',
+        content: '',
+        reason: decision.reason || 'The current draft is still only progress.',
+        usage: completionDecision.usage || 0,
+      };
+    }
+
+    const finalContent = String(decision.final_reply || lastReply || '').trim();
+    if (finalContent && messages[messages.length - 1]?.role === 'assistant') {
+      messages[messages.length - 1] = {
+        ...messages[messages.length - 1],
+        content: finalContent,
+      };
+      this.replaceLatestConversationAssistantMessage(conversationId, finalContent);
+    }
+
+    return {
+      action: decision.status === 'blocked' ? 'blocked' : 'complete',
+      content: finalContent,
+      reason: decision.reason || '',
+      usage: completionDecision.usage || 0,
+    };
+  }
+
   buildMessagingHeartbeatText(runMeta, options = {}) {
     const stalled = options.stalled === true;
-    const fallbackStartedAtMs = Number.isFinite(runMeta?.startedAt) ? runMeta.startedAt : Date.now();
-    const startedAtMs = timestampMs(
+    const now = Date.now();
+    const runStartedAtMs = Number.isFinite(runMeta?.startedAt) ? runMeta.startedAt : now;
+    const stepStartedAtMs = timestampMs(
       runMeta?.progressLedger?.currentStepStartedAt,
-      fallbackStartedAtMs,
+      0,
     );
-    const elapsed = formatElapsedDuration(Date.now() - startedAtMs);
+    const runElapsed = formatElapsedDuration(now - runStartedAtMs);
+    const stepElapsed = formatElapsedDuration(now - (stepStartedAtMs || runStartedAtMs));
+    const unverifiedElapsed = formatElapsedDuration(now - timestampMs(
+      runMeta?.progressLedger?.lastVerifiedProgressAt,
+      runStartedAtMs,
+    ));
     const currentTool = String(runMeta?.progressLedger?.currentTool || '').trim();
     if (currentTool) {
       return stalled
-        ? `Still working on ${currentTool}. This run has not made verified progress for ${elapsed}.`
-        : `Still working on ${currentTool}. ${elapsed} elapsed so far.`;
+        ? `Still working on ${currentTool}. Run active ${runElapsed}; no verified progress for ${unverifiedElapsed}.`
+        : `Still working on ${currentTool}. Run active ${runElapsed}; current step ${stepElapsed} so far.`;
     }
     return stalled
-      ? `Still working on this. This run has not made verified progress for ${elapsed}.`
-      : `Still working on this. ${elapsed} elapsed so far.`;
+      ? `Still working on this. Run active ${runElapsed}; no verified progress for ${unverifiedElapsed}.`
+      : `Still working on this. Run active ${runElapsed}.`;
   }
 
   async sendRuntimeMessagingHeartbeat(runId, options = {}) {
@@ -2317,6 +2788,7 @@ class AgentEngine {
     const carriedExplicitMessageSent = retryMessagingState.explicitMessageSent === true;
     const carriedInterimHistory = cloneInterimHistory(retryMessagingState.interimHistory);
     const carriedLastInterimMessage = carriedInterimHistory[carriedInterimHistory.length - 1]?.content || '';
+    const carriedGoalContract = normalizeGoalContract(retryMessagingState.goalContract);
     const startedAtIso = isoNow();
     const progressLedger = buildInitialProgressLedger({
       startedAt: startedAtIso,
@@ -2358,10 +2830,12 @@ class AgentEngine {
           chatId: options.chatId || null,
         }
         : null,
+      goalContract: carriedGoalContract,
       progressLedger,
     });
     this.persistRunMetadata(runId, {
       progressLedger,
+      goalContract: carriedGoalContract,
     });
     this.startMessagingProgressSupervisor(runId);
     this.emit(userId, 'run:start', { runId, agentId, title: runTitle, model, triggerType, triggerSource });
@@ -2459,6 +2933,12 @@ class AgentEngine {
     if (threadStateMessage) {
       messages.push({ role: 'system', content: threadStateMessage });
     }
+    if (carriedGoalContract) {
+      messages.push({
+        role: 'system',
+        content: buildGoalContractPrompt(carriedGoalContract, 'Persisted run goal'),
+      });
+    }
     this.recordRunEvent(userId, runId, 'memory_injected', {
       hasRecallContext: Boolean(recallMsg),
       hasThreadState: Boolean(threadStateMessage),
@@ -2537,6 +3017,7 @@ class AgentEngine {
           taskAnalysis: analysis,
           capabilityHealth,
         });
+        this.updateRunGoalContract(runId, goalContractFromAnalysis(analysis));
         this.emit(userId, 'run:analysis', {
           runId,
           ...analysis,
@@ -2655,6 +3136,9 @@ class AgentEngine {
               plan: deliverablePlan,
             },
           });
+          this.updateRunGoalContract(runId, {
+            goal: deliverableWorkflow.selection.goal,
+          });
           this.recordRunEvent(userId, runId, 'deliverable_workflow_selected', {
             type: deliverableWorkflow.selection.type,
             confidence: deliverableWorkflow.selection.confidence,
@@ -2691,6 +3175,7 @@ class AgentEngine {
             JSON.stringify(plan).slice(0, 20000)
           );
         this.persistRunMetadata(runId, { executionPlan: plan });
+        this.updateRunGoalContract(runId, goalContractFromPlan(plan));
         this.emit(userId, 'run:plan', {
           runId,
           steps: plan.steps,
@@ -2699,6 +3184,13 @@ class AgentEngine {
         });
       }
 
+      const runGoalContract = this.getRunMeta(runId)?.goalContract || null;
+      if (runGoalContract) {
+        messages.push({
+          role: 'system',
+          content: buildGoalContractPrompt(runGoalContract, 'Run goal contract'),
+        });
+      }
       messages.push({
         role: 'system',
         content: buildExecutionGuidance({
@@ -2952,6 +3444,43 @@ class AgentEngine {
             messagingSent,
             lastReply: lastContent,
           })) {
+            break;
+          }
+          const runMetaAfterResponse = this.getRunMeta(runId);
+          if (shouldRequireMessagingFinalityCheck(runMetaAfterResponse)) {
+            const messagingCompletion = await this.resolveMessagingCompletionDecision({
+              provider,
+              providerName,
+              model,
+              messages,
+              analysis,
+              plan,
+              tools,
+              toolExecutions,
+              lastReply: lastContent,
+              iteration,
+              maxIterations,
+              runId,
+              conversationId,
+              options: { ...options, runId, userId, agentId },
+            });
+            totalTokens += messagingCompletion.usage || 0;
+            if (messagingCompletion.action === 'continue') {
+              messages.push({
+                role: 'system',
+                content: [
+                  messagingCompletion.reason
+                    ? `Continue working: ${messagingCompletion.reason}.`
+                    : 'Continue working autonomously.',
+                  'The messaging user has already seen progress. Do not stop until you either have the finished answer now or a concrete blocker reply now.',
+                ].join(' ')
+              });
+              lastContent = '';
+              continue;
+            }
+            if (typeof messagingCompletion.content === 'string') {
+              lastContent = messagingCompletion.content;
+            }
             break;
           }
           if (iteration < maxIterations) {
@@ -3784,6 +4313,10 @@ class AgentEngine {
               ...(Array.isArray(options?.messagingRetryState?.interimHistory) ? options.messagingRetryState.interimHistory : []),
               ...(Array.isArray(runMeta?.interimMessages) ? runMeta.interimMessages : []),
             ]),
+            goalContract: mergeGoalContracts(
+              options?.messagingRetryState?.goalContract || null,
+              runMeta?.goalContract || null,
+            ),
             lastUserVisibleUpdateAt: runMeta?.progressLedger?.lastUserVisibleUpdateAt || options?.messagingRetryState?.lastUserVisibleUpdateAt || null,
             lastFinalDeliveryAt: runMeta?.progressLedger?.lastFinalDeliveryAt || options?.messagingRetryState?.lastFinalDeliveryAt || null,
             heartbeatCount: Number(runMeta?.progressLedger?.heartbeatCount || options?.messagingRetryState?.heartbeatCount || 0),

--- a/server/services/ai/engine.js
+++ b/server/services/ai/engine.js
@@ -137,6 +137,37 @@ function formatElapsedDuration(durationMs) {
   return `${minutes}m ${seconds}s`;
 }
 
+function normalizeErrorKey(errorMsg) {
+  const msg = String(errorMsg || '').toLowerCase();
+  if (/outside.*(workspace|per-user)/i.test(msg)) return 'outside_workspace';
+  if (/eisdir|illegal operation on a directory/i.test(msg)) return 'eisdir';
+  if (/enoent|no such file/i.test(msg)) return 'enoent';
+  if (/can.?t cd to|no such directory/i.test(msg)) return 'bad_cwd';
+  if (/not found/i.test(msg)) return 'not_found';
+  return msg.slice(0, 60);
+}
+
+function trackErrorPattern(errorMsg, runMeta) {
+  if (!errorMsg) return;
+  const key = normalizeErrorKey(errorMsg);
+  if (!runMeta.errorPatterns) runMeta.errorPatterns = new Map();
+  runMeta.errorPatterns.set(key, (runMeta.errorPatterns.get(key) || 0) + 1);
+}
+
+function buildErrorPatternGuidance(key, count) {
+  if (count < 3) return null;
+  const guides = {
+    outside_workspace: 'read_file cannot access /tmp paths. Use execute_command with `cat <path>` instead.',
+    eisdir: 'That path is a directory, not a file. Use list_directory or execute_command with `ls` to inspect it.',
+    enoent: 'That path does not exist. Use execute_command with `find . -name "..."` to locate the correct path first.',
+    bad_cwd: 'The VM home directory is not ~/. Use absolute paths starting from /tmp or discover the workspace root first.',
+    not_found: 'This path or resource was not found. Try listing the parent directory or checking with a broader search first.',
+  };
+  const guide = guides[key];
+  if (!guide) return null;
+  return `REPEATED ERROR (${count}×): ${guide}`;
+}
+
 function resolveModelCallTimeoutMs(options = {}) {
   const requested = Number(options?.modelCallTimeoutMs);
   if (Number.isFinite(requested) && requested > 0) {
@@ -1468,117 +1499,6 @@ class AgentEngine {
     };
   }
 
-  async decideLoopState({
-    provider,
-    providerName,
-    model,
-    messages,
-    tools,
-    analysis,
-    plan,
-    toolExecutions,
-    lastReply,
-    triggerSource,
-    messagingSent,
-    iteration,
-    maxIterations,
-    options,
-    fallbackStatus,
-  }) {
-    const runMeta = options?.runId ? this.getRunMeta(options.runId) : null;
-    const goalContext = resolveRunGoalContext(runMeta, analysis, plan);
-
-    const response = await this.requestStructuredJson({
-      provider,
-      providerName,
-      model,
-      messages,
-      prompt: buildCompletionDecisionPrompt({
-        triggerSource,
-        messagingSent,
-        goalContext,
-        parallelWork: analysis?.parallel_work === true,
-        tools,
-        toolExecutions,
-        lastReply,
-        iteration,
-        maxIterations,
-      }),
-      maxTokens: 320,
-      normalize: (raw) => normalizeCompletionDecision(raw, fallbackStatus),
-      fallback: { status: fallbackStatus },
-      reasoningEffort: this.getReasoningEffort(providerName, options),
-      telemetry: options,
-      phase: 'loop_decision',
-    });
-
-    return {
-      decision: response.value,
-      usage: response.usage,
-    };
-  }
-
-  async evaluateTaskCompleteSignal({
-    provider,
-    providerName,
-    model,
-    messages,
-    tools,
-    analysis,
-    plan,
-    toolExecutions,
-    finalMessage,
-    confidence,
-    triggerSource,
-    messagingSent,
-    iteration,
-    maxIterations,
-    options,
-  }) {
-    const runMeta = options?.runId ? this.getRunMeta(options.runId) : null;
-    const requiredConfidence = resolveRunGoalContext(runMeta, analysis, plan)
-      .effectiveCompletionConfidence;
-    const confidenceDecision = shouldAcceptTaskComplete({
-      confidence,
-      requiredConfidence,
-      iteration,
-      maxIterations,
-    });
-    if (!confidenceDecision.accept) {
-      return {
-        decision: {
-          status: 'continue',
-          reason: confidenceDecision.reason,
-        },
-        requiredConfidence,
-        usage: 0,
-      };
-    }
-
-    const loopState = await this.decideLoopState({
-      provider,
-      providerName,
-      model,
-      messages,
-      tools,
-      analysis,
-      plan,
-      toolExecutions,
-      lastReply: finalMessage,
-      triggerSource,
-      messagingSent,
-      iteration,
-      maxIterations,
-      options,
-      fallbackStatus: 'continue',
-    });
-    return {
-      decision: loopState.decision,
-      requiredConfidence,
-      usage: loopState.usage || 0,
-    };
-  }
-
   async verifyFinalResponse({
     provider,
     providerName,
@@ -1730,73 +1650,6 @@ class AgentEngine {
       invalidateSystemPromptCache(options.userId, options.agentId || null);
     }
     return nextState;
-  }
-
-  async recoverBlankMessagingReply({
-    userId,
-    runId,
-    messages,
-    provider,
-    model,
-    providerName,
-    options,
-    stepIndex,
-    failedStepCount,
-    toolExecutions = [],
-    tools = []
-  }) {
-    const attempts = 3;
-    let recoveredContent = '';
-    let totalTokens = 0;
-
-    for (let attempt = 1; attempt <= attempts; attempt++) {
-      console.warn(
-        `[Run ${shortenRunId(runId)}] blank_reply_recovery attempt=${attempt} model=${model}`
-      );
-      try {
-        const response = await withModelCallTimeout(
-          provider.chat(
-            sanitizeConversationMessages([
-              ...messages,
-              {
-                role: 'system',
-                content: buildBlankMessagingReplyPrompt(attempt, options?.source || null)
-              }
-            ]),
-            [],
-            {
-              model,
-              reasoningEffort: this.getReasoningEffort(providerName, options)
-            }
-          ),
-          options,
-          `Blank messaging reply recovery ${attempt}`,
-        );
-        totalTokens += response.usage?.totalTokens || 0;
-        recoveredContent = sanitizeModelOutput(response.content || '', { model });
-        if (normalizeOutgoingMessage(recoveredContent)) {
-          console.info(
-            `[Run ${shortenRunId(runId)}] blank_reply_recovery succeeded attempt=${attempt}`
-          );
-          return { content: recoveredContent, tokens: totalTokens, recovered: true };
-        }
-      } catch (recoverErr) {
-        console.warn(
-          `[Run ${shortenRunId(runId)}] blank_reply_recovery attempt=${attempt} failed: ${summarizeForLog(recoverErr?.message || recoverErr, 180)}`
-        );
-      }
-    }
-
-    const error = new Error(
-      buildDeterministicMessagingFallback({
-        failedStepCount,
-        stepIndex,
-        toolExecutions,
-      })
-    );
-    error.code = 'BLANK_MESSAGING_REPLY';
-    error.recoveryTokens = totalTokens;
-    throw error;
   }
 
   getAvailableTools(app, options = {}) {
@@ -2216,14 +2069,16 @@ class AgentEngine {
       runStartedAtMs,
     ));
     const currentTool = String(runMeta?.progressLedger?.currentTool || '').trim();
+    const runTitle = String(runMeta?.title || '').trim().slice(0, 60);
+    const titlePrefix = runTitle ? `[${runTitle}] ` : '';
     if (currentTool) {
       return stalled
-        ? `Still working on ${currentTool}. Run active ${runElapsed}; no verified progress for ${unverifiedElapsed}.`
-        : `Still working on ${currentTool}. Run active ${runElapsed}; current step ${stepElapsed} so far.`;
+        ? `${titlePrefix}Still working on ${currentTool}. Run active ${runElapsed}; no verified progress for ${unverifiedElapsed}.`
+        : `${titlePrefix}Still working on ${currentTool}. Run active ${runElapsed}; current step ${stepElapsed} so far.`;
     }
     return stalled
-      ? `Still working on this. Run active ${runElapsed}; no verified progress for ${unverifiedElapsed}.`
-      : `Still working on this. Run active ${runElapsed}.`;
+      ? `${titlePrefix}Still working on this. Run active ${runElapsed}; no verified progress for ${unverifiedElapsed}.`
+      : `${titlePrefix}Still working on this. Run active ${runElapsed}.`;
   }
 
   async sendRuntimeMessagingHeartbeat(runId, options = {}) {
@@ -2281,8 +2136,8 @@ class AgentEngine {
     }, { agentId: runMeta.agentId });
     this.enqueueSystemSteering(
       runId,
-      'A runtime-generated progress update was already sent while the run was blocked. Do not repeat that same status. When control returns, either keep working silently, send a materially new update, or finish with the actual result.',
-      { reason: 'runtime_heartbeat' },
+      'A runtime progress update was just sent on your behalf because you were blocked in a tool. On your NEXT free turn: use send_interim_update to write 1-2 sentences in your own words describing what you are doing and why. Keep it short and concrete. Then continue toward the final answer.',
+      { reason: 'heartbeat_ai_followup' },
     );
     return { sent: true, content };
   }
@@ -2424,9 +2279,10 @@ class AgentEngine {
       return { sent: false, skipped: true };
     }
 
+    const elapsed = formatElapsedDuration(now - startedAtMs);
     const nudge = stalled
-      ? 'The messaging user has only seen progress updates so far, and the run now appears stalled. Decide explicitly whether to continue, send one concise blocker update, or finish with the final answer. Do not leave the run with only an interim status.'
-      : 'The messaging user has not received a final answer yet. Decide explicitly whether to keep working, send one concise progress update, or finish with the final answer. Do not stop with only an interim status.';
+      ? `You have been running for ${elapsed} and appear stalled. Use send_interim_update RIGHT NOW to write 1-2 sentences explaining the blocker in your own words, then either resolve it or call task_complete with what you have. Do not leave the user without an answer.`
+      : `You have been running for ${elapsed} without sending an update to the user. Use send_interim_update RIGHT NOW to write 1-2 sentences explaining what you are currently doing. Keep it short and concrete. Then continue working toward the final answer.`;
     const queued = this.enqueueSystemSteering(runId, nudge, {
       reason: stalled ? 'stalled_progress_check' : 'progress_check',
     });
@@ -3165,37 +3021,6 @@ class AgentEngine {
           db.prepare('INSERT INTO conversation_messages (conversation_id, role, content, tokens) VALUES (?, ?, ?, ?)')
             .run(conversationId, 'assistant', lastContent, analysisUsage);
         }
-        const directAnswerDecision = await runWithModelFallback(
-          'direct answer completion decision',
-          () => this.decideLoopState({
-            provider,
-            providerName,
-            model,
-            messages,
-            tools,
-            analysis,
-            plan,
-            toolExecutions,
-            lastReply: lastContent,
-            triggerSource,
-            messagingSent: false,
-            iteration,
-            maxIterations,
-            options: { ...options, runId, userId, agentId },
-            fallbackStatus: 'continue',
-          }),
-        );
-        totalTokens += directAnswerDecision.usage || 0;
-        if (directAnswerDecision.decision.status === 'continue') {
-          messages.push({
-            role: 'system',
-            content: directAnswerDecision.decision.reason
-              ? `Continue working: ${directAnswerDecision.decision.reason}.`
-              : 'The initial draft is not a finished answer. Continue working autonomously.',
-          });
-          lastContent = '';
-          directAnswerEligible = false;
-        }
       }
 
       // BUG FIX: consecutiveToolFailures was previously declared INSIDE the
@@ -3395,6 +3220,9 @@ class AgentEngine {
             currentTool: null,
             currentStepStartedAt: null,
           });
+          // Check for queued steering first — if something was injected while the
+          // model was responding (e.g. a heartbeat nudge), give the model a chance
+          // to act on it before we treat this as a final answer.
           const systemSteeringAfterResponse = this.applyQueuedSystemSteering(runId, messages);
           messages = systemSteeringAfterResponse.messages;
           if (systemSteeringAfterResponse.appliedCount > 0) {
@@ -3412,65 +3240,17 @@ class AgentEngine {
             lastContent = '';
             continue;
           }
-          const messagingSent = this.activeRuns.get(runId)?.messagingSent || false;
           if (this.shouldFastCompleteVoiceReply({
             options,
             toolExecutions,
             failedStepCount,
-            messagingSent,
+            messagingSent: this.activeRuns.get(runId)?.messagingSent || false,
             lastReply: lastContent,
           })) {
             break;
           }
-          const proactiveRunNeedsDecision = (
-            (triggerSource === 'schedule' || triggerSource === 'tasks')
-            && this.activeRuns.get(runId)?.noResponse !== true
-            && options.deliveryState?.noResponse !== true
-          );
-          const visibleInterimActivity = hasVisibleInterimActivity(this.activeRuns.get(runId));
-          const fallbackStatus = (
-            proactiveRunNeedsDecision
-            || toolExecutions.length > 0
-            || failedStepCount > 0
-            || messagingSent
-            || visibleInterimActivity
-          ) ? 'continue' : 'complete';
-          const loopState = await runWithModelFallback('loop decision', () => this.decideLoopState({
-            provider,
-            providerName,
-            model,
-            messages,
-            tools,
-            analysis,
-            plan,
-            toolExecutions,
-            lastReply: lastContent,
-            triggerSource,
-            messagingSent,
-            iteration,
-            maxIterations,
-            options: { ...options, runId, userId, agentId },
-            fallbackStatus,
-          }));
-          totalTokens += loopState.usage || 0;
-          if (loopState.decision.status === 'continue') {
-            if (iteration >= maxIterations) {
-              throw new Error(
-                `Completion judge found unfinished work at the iteration limit after ${maxIterations} iterations.`,
-              );
-            }
-            messages.push({
-              role: 'system',
-              content: [
-                loopState.decision.reason ? `Continue working: ${loopState.decision.reason}.` : 'Continue working autonomously.',
-                messagingSent
-                  ? 'You already sent a user-facing message in this run. Keep working silently unless you have a materially new finished result or a real external blocker.'
-                  : 'Use send_interim_update sparingly if a short real update or question would help. Otherwise keep working until you have the result or a real blocker.',
-              ].join(' ')
-            });
-            lastContent = '';
-            continue;
-          }
+          // AI returned text with no tool calls → trust it as the final answer.
+          directAnswerEligible = true;
           break;
         }
 
@@ -3564,82 +3344,20 @@ class AgentEngine {
           }
 
           // ── task_complete: AI explicitly signals the task is fully done ──
-          // Handle before DB insert / before_tool_call hook — this is not a
-          // regular tool execution, it is a loop-exit signal.
+          // Trust the model — no separate judge LLM call needed.
           if (toolName === 'task_complete') {
             const finalMessage = String(toolArgs.message || '').trim();
-            const confidence = normalizeCompletionConfidence(toolArgs.confidence || 'medium');
-            const messagingSent = this.getRunMeta(runId)?.messagingSent === true;
-            const completionResult = await runWithModelFallback(
-              'task completion decision',
-              () => this.evaluateTaskCompleteSignal({
-                provider,
-                providerName,
-                model,
-                messages,
-                tools,
-                analysis,
-                plan,
-                toolExecutions,
-                finalMessage,
-                confidence,
-                triggerSource,
-                messagingSent,
-                iteration,
-                maxIterations,
-                options: { ...options, runId, userId, agentId },
-              }),
-            );
-            totalTokens += completionResult.usage || 0;
-            const completionDecision = completionResult.decision || {
-              status: 'continue',
-              reason: 'The completion signal could not be verified.',
-            };
-            const accepted = completionDecision.status !== 'continue';
             this.recordRunEvent(userId, runId, 'task_complete_signaled', {
-              confidence,
-              requiredConfidence: completionResult.requiredConfidence,
-              accepted,
-              judgeStatus: completionDecision.status,
-              judgeReason: completionDecision.reason || '',
+              accepted: true,
               iteration,
               messageLength: finalMessage.length,
             }, { agentId });
             console.info(
-              `[Run ${shortenRunId(runId)}] task_complete signaled at iteration=${iteration} confidence=${confidence} judge=${completionDecision.status} accepted=${accepted}`
+              `[Run ${shortenRunId(runId)}] task_complete accepted at iteration=${iteration}`
             );
-            if (!accepted) {
-              if (iteration >= maxIterations) {
-                throw new Error(
-                  `Completion judge rejected task_complete at the iteration limit after ${maxIterations} iterations.`,
-                );
-              }
-              messages.push({
-                role: 'tool',
-                name: toolName,
-                tool_call_id: toolCall.id,
-                content: JSON.stringify({
-                  status: 'continue',
-                  reason: completionDecision.reason,
-                  required_confidence: completionResult.requiredConfidence,
-                }),
-              });
-              messages.push({
-                role: 'system',
-                content: `${completionDecision.reason} Do not ask the user to decide the next step unless external input is truly required.`
-              });
-              lastContent = '';
-              continue;
-            }
-            if (completionDecision.reason) {
-              messages.push({
-                role: 'system',
-                content: completionDecision.reason,
-              });
-            }
-            lastContent = finalMessage; // empty string is valid; downstream handles it
+            lastContent = finalMessage;
             directAnswerEligible = true;
-            break; // exit the for-loop; the while condition will also exit
+            break;
           }
 
           const repetitionGuard = this.getRunMeta(runId)?.repetitionGuard;
@@ -3849,6 +3567,11 @@ class AgentEngine {
 
           if (toolErrorMessage) {
             consecutiveToolFailures += 1;
+            const currentRunMeta = this.getRunMeta(runId);
+            trackErrorPattern(toolErrorMessage, currentRunMeta);
+            const errorKey = normalizeErrorKey(toolErrorMessage);
+            const errorCount = currentRunMeta?.errorPatterns?.get(errorKey) || 0;
+            const patternGuide = buildErrorPatternGuidance(errorKey, errorCount);
             const alternativeTools = summarizeAvailableTools(tools, { exclude: toolName });
             messages.push({
               role: 'system',
@@ -3857,6 +3580,7 @@ class AgentEngine {
                 'This tool failure is not, by itself, a user-facing blocker.',
                 'Continue autonomously: retry with corrected arguments, try an alternative tool/path, or verify the outcome using other available tools.',
                 alternativeTools ? `Other available tools in this run: ${alternativeTools}.` : '',
+                patternGuide || '',
                 'Only stop and tell the user you are blocked if the remaining issue truly requires an external dependency or user action outside this run.'
               ].filter(Boolean).join(' ')
             });
@@ -3965,26 +3689,43 @@ class AgentEngine {
       const lastToolWasMessaging = runMeta?.lastToolName === 'send_message' || runMeta?.lastToolName === 'make_call';
 
       if (triggerSource === 'messaging' && !normalizeOutgoingMessage(lastContent, options?.source || null) && !messagingSent) {
-        const recovered = await this.recoverBlankMessagingReply({
-          userId,
-          runId,
-          messages,
-          provider,
-          model,
-          providerName,
-          options: { ...options, runId, userId, agentId },
-          stepIndex,
-          failedStepCount,
-          toolExecutions,
-          tools
-        });
-        lastContent = recovered.content;
-        totalTokens += recovered.tokens || 0;
+        // Simplified blank reply recovery: one model call with direct instruction,
+        // then fall back to a deterministic message. No multi-attempt LLM loop.
+        console.warn(`[Run ${shortenRunId(runId)}] blank_reply_recovery model=${model}`);
+        let recoveredTokens = 0;
+        try {
+          const recoveryResponse = await withModelCallTimeout(
+            provider.chat(
+              sanitizeConversationMessages([
+                ...messages,
+                {
+                  role: 'system',
+                  content: buildBlankMessagingReplyPrompt(1, options?.source || null)
+                }
+              ]),
+              [],
+              {
+                model,
+                reasoningEffort: this.getReasoningEffort(providerName, options)
+              }
+            ),
+            options,
+            'Blank messaging reply recovery',
+          );
+          recoveredTokens = recoveryResponse.usage?.totalTokens || 0;
+          lastContent = sanitizeModelOutput(recoveryResponse.content || '', { model });
+        } catch (recoverErr) {
+          console.warn(`[Run ${shortenRunId(runId)}] blank_reply_recovery failed: ${summarizeForLog(recoverErr?.message || recoverErr, 180)}`);
+        }
+        totalTokens += recoveredTokens;
+        if (!normalizeOutgoingMessage(lastContent, options?.source || null)) {
+          lastContent = buildDeterministicMessagingFallback({ failedStepCount, stepIndex, toolExecutions });
+        }
         if (normalizeOutgoingMessage(lastContent, options?.source || null)) {
           messages.push({ role: 'assistant', content: lastContent });
           if (conversationId) {
             db.prepare('INSERT INTO conversation_messages (conversation_id, role, content, tokens) VALUES (?, ?, ?, ?)')
-              .run(conversationId, 'assistant', lastContent, recovered.tokens || 0);
+              .run(conversationId, 'assistant', lastContent, recoveredTokens);
           }
         }
       }

--- a/server/services/ai/loopPolicy.js
+++ b/server/services/ai/loopPolicy.js
@@ -20,7 +20,6 @@ const DEFAULT_PLAN_EXECUTE_MAX_ITERATIONS = 40;
 const DEFAULT_COMPACTION_THRESHOLD = 0.82;
 const DEFAULT_MAX_CONSECUTIVE_TOOL_FAILURES = 5;
 const DEFAULT_MAX_MODEL_FAILURE_RECOVERIES = 3;
-const DEFAULT_MAX_STAGNANT_ITERATIONS = 15;
 
 // Hard ceilings — protect against runaway config values
 const MAX_ALLOWED_ITERATIONS = 200;
@@ -116,7 +115,6 @@ function buildLoopPolicy(aiSettings = {}, triggerType = 'chat', analysisMode = '
     maxIterations,
     maxConsecutiveToolFailures,
     maxModelFailureRecoveries,
-    maxStagnantIterations: DEFAULT_MAX_STAGNANT_ITERATIONS,
 
     // Fill ratio at which context compaction triggers (0–1)
     compactionThreshold,

--- a/server/services/ai/loopPolicy.js
+++ b/server/services/ai/loopPolicy.js
@@ -20,6 +20,7 @@ const DEFAULT_PLAN_EXECUTE_MAX_ITERATIONS = 40;
 const DEFAULT_COMPACTION_THRESHOLD = 0.82;
 const DEFAULT_MAX_CONSECUTIVE_TOOL_FAILURES = 5;
 const DEFAULT_MAX_MODEL_FAILURE_RECOVERIES = 3;
+const DEFAULT_MAX_STAGNANT_ITERATIONS = 15;
 
 // Hard ceilings — protect against runaway config values
 const MAX_ALLOWED_ITERATIONS = 200;
@@ -115,6 +116,7 @@ function buildLoopPolicy(aiSettings = {}, triggerType = 'chat', analysisMode = '
     maxIterations,
     maxConsecutiveToolFailures,
     maxModelFailureRecoveries,
+    maxStagnantIterations: DEFAULT_MAX_STAGNANT_ITERATIONS,
 
     // Fill ratio at which context compaction triggers (0–1)
     compactionThreshold,

--- a/server/services/ai/tools.js
+++ b/server/services/ai/tools.js
@@ -9,6 +9,7 @@ const {
     normalizeOutgoingMessageForPlatform,
 } = require('../messaging/formatting_guides');
 const { INTERIM_KINDS, normalizeInterimKind } = require('./interim');
+const { normalizeWhatsAppId } = require('../../utils/whatsapp');
 const {
     executeIntegratedTool,
     getIntegratedToolDefinitions,
@@ -318,6 +319,31 @@ function normalizeMessagingTarget(target = {}) {
     const to = normalizeStoredSettingString(target.to);
     if (!platform || !to) return null;
     return { platform, to };
+}
+
+function canonicalMessagingAddress(platform, value) {
+    const normalizedPlatform = String(platform || '').trim().toLowerCase();
+    const raw = String(value || '').trim();
+    if (!normalizedPlatform || !raw) return '';
+    if (normalizedPlatform !== 'whatsapp') return raw;
+
+    const lower = raw.toLowerCase();
+    const normalizedId = normalizeWhatsAppId(lower);
+    if (!normalizedId) return '';
+    if (lower.includes('@g.us')) return `group:${normalizedId}`;
+    if (lower.includes('@lid')) return `lid:${normalizedId}`;
+    return `direct:${normalizedId}`;
+}
+
+function isOriginMessagingDelivery({ triggerSource, source, chatId, platform, to }) {
+    if (triggerSource !== 'messaging') return true;
+    const originPlatform = String(source || '').trim().toLowerCase();
+    const targetPlatform = String(platform || '').trim().toLowerCase();
+    if (!originPlatform || !targetPlatform || originPlatform !== targetPlatform) return false;
+
+    const originAddress = canonicalMessagingAddress(originPlatform, chatId);
+    const targetAddress = canonicalMessagingAddress(targetPlatform, to);
+    return Boolean(originAddress && targetAddress && originAddress === targetAddress);
 }
 
 function buildAndroidUiMatchProperties(extra = {}) {
@@ -2244,7 +2270,18 @@ async function executeTool(toolName, args, context, engine) {
                 persistConversation: triggerSource === 'schedule' || triggerSource === 'tasks'
             });
             // Track that the agent explicitly sent a message during this run
-            if (!suppressReply && sendResult?.suppressed !== true) {
+            if (
+                !suppressReply
+                && sendResult?.success === true
+                && sendResult?.suppressed !== true
+                && isOriginMessagingDelivery({
+                    triggerSource,
+                    source: context.source,
+                    chatId: context.chatId,
+                    platform: args.platform,
+                    to: args.to,
+                })
+            ) {
                 markProactiveMessageSent({ runState, deliveryState, content: normalizedMessage });
                 if (runState && triggerSource === 'messaging') {
                     runState.explicitMessageSent = true;

--- a/server/services/ai/tools.js
+++ b/server/services/ai/tools.js
@@ -255,22 +255,32 @@ function hasAlreadySentProactiveMessage({ triggerSource, runState, deliveryState
 }
 
 function markProactiveMessageSent({ runState, deliveryState, content }) {
-    const message = String(content || '');
-    if (runState) {
-        runState.messagingSent = true;
-        runState.lastSentMessage = message;
-        if (Array.isArray(runState.sentMessages)) {
-            runState.sentMessages.push(message);
-        }
+  const message = String(content || '');
+  const sentAt = new Date().toISOString();
+  if (runState) {
+    runState.messagingSent = true;
+    runState.finalDeliverySent = true;
+    runState.lastFinalDeliveryAt = sentAt;
+    if (runState.progressLedger && typeof runState.progressLedger === 'object') {
+      runState.progressLedger.lastUserVisibleUpdateAt = sentAt;
+      runState.progressLedger.lastFinalDeliveryAt = sentAt;
+      runState.progressLedger.progressState = 'complete';
     }
+    runState.lastSentMessage = message;
+    if (Array.isArray(runState.sentMessages)) {
+      runState.sentMessages.push(message);
+    }
+  }
 
-    if (deliveryState) {
-        deliveryState.messagingSent = true;
-        deliveryState.lastSentMessage = message;
-        if (!Array.isArray(deliveryState.sentMessages)) {
-            deliveryState.sentMessages = [];
-        }
-        deliveryState.sentMessages.push(message);
+  if (deliveryState) {
+    deliveryState.messagingSent = true;
+    deliveryState.finalDeliverySent = true;
+    deliveryState.lastFinalDeliveryAt = sentAt;
+    deliveryState.lastSentMessage = message;
+    if (!Array.isArray(deliveryState.sentMessages)) {
+      deliveryState.sentMessages = [];
+    }
+    deliveryState.sentMessages.push(message);
     }
 }
 

--- a/server/services/ai/tools.js
+++ b/server/services/ai/tools.js
@@ -1649,6 +1649,7 @@ async function executeTool(toolName, args, context, engine) {
         case 'browser_extract': {
             const { provider, backend } = await bc();
             if (!provider) return { error: 'Browser controller not available' };
+            if (!args.selector) return { error: 'browser_extract requires a "selector" argument' };
             return { ...await provider.extract(args.selector, args.attribute, args.all), backend };
         }
 
@@ -1661,7 +1662,9 @@ async function executeTool(toolName, args, context, engine) {
         case 'browser_evaluate': {
             const { provider, backend } = await bc();
             if (!provider) return { error: 'Browser controller not available' };
-            return { ...await provider.evaluate(args.script), backend };
+            const script = args.script ?? args.javascript;
+            if (!script) return { error: 'browser_evaluate requires a "script" argument' };
+            return { ...await provider.evaluate(script), backend };
         }
 
         case 'android_start_emulator': {

--- a/server/services/ai/tools.js
+++ b/server/services/ai/tools.js
@@ -1111,7 +1111,7 @@ function getAvailableTools(app, options = {}) {
                 properties: {
                     name: { type: 'string', description: 'Short descriptive name for the task.' },
                     trigger: { type: 'object', description: 'Unified trigger object. Prefer { type: "manual" | "schedule" | integration_trigger_type, config: {...} }.' },
-                    trigger_type: { type: 'string', description: 'Trigger type such as manual, schedule, gmail_message_received, outlook_email_received, slack_message_received, teams_message_received, weather_event, or whatsapp_personal_message_received.' },
+                    trigger_type: { type: 'string', description: 'Trigger type such as manual, schedule, gmail_message_received, outlook_email_received, slack_message_received, teams_message_received, weather_event, whatsapp_personal_message_received, or android_notification_received.' },
                     trigger_config: { type: 'object', description: 'Trigger-specific configuration object. For schedule triggers prefer { mode: "recurring", cronExpression: "m h dom mon dow" } or { mode: "one_time", runAt: ISO datetime }. 5-field cron only (seconds unsupported).' },
                     prompt: { type: 'string', description: 'The instructions the agent will run when the trigger fires.' },
                     enabled: { type: 'boolean', description: 'Whether to activate immediately.' },

--- a/server/services/messaging/manager.js
+++ b/server/services/messaging/manager.js
@@ -515,6 +515,13 @@ class MessagingManager extends EventEmitter {
     }
 
     const result = await platform.sendMessage(to, normalizedContent, sendOptions);
+    if (result?.success === false) {
+      const reason = result.error || result.reason || 'platform rejected the message';
+      const error = new Error(`Platform ${platformName} delivery failed: ${reason}`);
+      error.code = 'MESSAGING_DELIVERY_FAILED';
+      error.deliveryResult = result;
+      throw error;
+    }
 
     db.prepare('INSERT INTO messages (user_id, agent_id, run_id, role, content, platform, platform_chat_id, media_path, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
       .run(userId, agentId, runId, 'assistant', normalizedContent, platformName, to, mediaPath, metadata ? JSON.stringify(metadata) : null);

--- a/server/services/runtime/backends/local-vm.js
+++ b/server/services/runtime/backends/local-vm.js
@@ -250,8 +250,8 @@ class VmBrowserProvider {
   async typeText(text, options = {}) { return this.#materialize(await this.client.request('POST', '/browser/type-text', { text, ...options })); }
   async pressKey(key, screenshot = true) { return this.#materialize(await this.client.request('POST', '/browser/press-key', { key, screenshot })); }
   async scroll(deltaX, deltaY, screenshot = true) { return this.#materialize(await this.client.request('POST', '/browser/scroll', { deltaX, deltaY, screenshot })); }
-  extract(selector, attribute, all = false) { return this.client.request('POST', '/browser/extract', { selector, attribute, all }); }
-  evaluate(script) { return this.client.request('POST', '/browser/execute', { code: script }); }
+  async extract(selector, attribute, all = false) { return this.client.request('POST', '/browser/extract', { selector, attribute, all }); }
+  async evaluate(script) { return this.client.request('POST', '/browser/execute', { code: script }); }
   async screenshot(options = {}) { return this.#materialize(await this.client.request('POST', '/browser/screenshot', options)); }
   async screenshotJpeg(quality = 80, options = {}) {
     const result = await this.client.request('POST', '/browser/screenshot-jpeg', { ...options, quality });
@@ -259,11 +259,11 @@ class VmBrowserProvider {
     if (!content) throw new Error('VM browser screenshot-jpeg returned no data.');
     return Buffer.from(content, 'base64');
   }
-  launch(options = {}) { return this.client.request('POST', '/browser/launch', options); }
-  closeBrowser() { return this.client.request('POST', '/browser/close'); }
-  fill(selector, value) { return this.type(selector, value); }
-  extractContent(options = {}) { return this.client.request('POST', '/browser/extract', options); }
-  executeJS(code) { return this.evaluate(code); }
+  async launch(options = {}) { return this.client.request('POST', '/browser/launch', options); }
+  async closeBrowser() { return this.client.request('POST', '/browser/close'); }
+  async fill(selector, value) { return this.type(selector, value); }
+  async extractContent(options = {}) { return this.client.request('POST', '/browser/extract', options); }
+  async executeJS(code) { return this.evaluate(code); }
   async getPageInfo() {
     const status = await this.client.request('GET', '/browser/status');
     this.headless = status?.headless !== false;

--- a/server/services/tasks/adapters/android_notification_received.js
+++ b/server/services/tasks/adapters/android_notification_received.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { normalizeTrimmedText } = require('../security');
+
+module.exports = {
+  type: 'android_notification_received',
+  label: 'Android Notification Received',
+  async validateConfig(config = {}, context = {}) {
+    return {
+      appPackage: normalizeTrimmedText(config.appPackage || config.app_package, 200),
+    };
+  },
+  summarize(config = {}) {
+    const parts = ['Android Notification'];
+    if (config.appPackage) parts.push(`app: ${config.appPackage}`);
+    return parts.join(' · ');
+  },
+};

--- a/server/services/tasks/adapters/index.js
+++ b/server/services/tasks/adapters/index.js
@@ -9,5 +9,7 @@ module.exports = [
   require('./slack_message_received'),
   require('./teams_message_received'),
   require('./weather_event'),
+  require('./webhook'),
   require('./whatsapp_personal_message_received'),
+  require('./android_notification_received'),
 ];

--- a/test/backend/unit/engine_model_response.test.js
+++ b/test/backend/unit/engine_model_response.test.js
@@ -166,3 +166,62 @@ test('requestModelResponse does not retry once stream content has been emitted',
   );
   assert.equal(calls, 1);
 });
+
+test('requestModelResponse times out a model call that never settles', async () => {
+  const engine = new AgentEngine(null);
+
+  await assert.rejects(
+    engine.requestModelResponse({
+      provider: {
+        async chat() {
+          return new Promise(() => {});
+        },
+      },
+      providerName: 'test',
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'Run the task.' }],
+      tools: [],
+      options: {
+        stream: false,
+        userId: 1,
+        modelCallTimeoutMs: 20,
+        retry: { maxAttempts: 1 },
+      },
+      runId: 'timeout-run',
+      iteration: 1,
+    }),
+    (error) => error.code === 'MODEL_CALL_TIMEOUT',
+  );
+});
+
+test('requestModelResponse times out a stalled stream without replaying partial output', async () => {
+  const engine = new AgentEngine(null);
+  let calls = 0;
+
+  await assert.rejects(
+    engine.requestModelResponse({
+      provider: {
+        async *stream() {
+          calls += 1;
+          yield { type: 'content', content: 'partial' };
+          await new Promise(() => {});
+        },
+      },
+      providerName: 'test',
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'Run the task.' }],
+      tools: [],
+      options: {
+        stream: true,
+        userId: 1,
+        modelCallTimeoutMs: 20,
+        retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
+      },
+      runId: 'stream-timeout-run',
+      iteration: 1,
+    }),
+    (error) => error.code === 'MODEL_CALL_TIMEOUT',
+  );
+
+  assert.equal(calls, 1);
+});

--- a/test/backend/unit/messaging_manager_delivery.test.js
+++ b/test/backend/unit/messaging_manager_delivery.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { afterEach, beforeEach, test } = require('node:test');
+
+const {
+  createTestRuntime,
+  createTestUser,
+  teardownTestRuntime,
+} = require('../../helpers/db');
+
+let ctx;
+let user;
+let MessagingManager;
+
+beforeEach(async () => {
+  ctx = createTestRuntime();
+  user = await createTestUser(ctx.db);
+  ({ MessagingManager } = require('../../../server/services/messaging/manager'));
+});
+
+afterEach(() => {
+  teardownTestRuntime(ctx);
+});
+
+test('messaging manager rejects an unconfirmed platform delivery before persistence', async () => {
+  const io = {
+    to() {
+      return { emit() {} };
+    },
+  };
+  const manager = new MessagingManager(io);
+  const agentId = manager._agentId(user.userId, {});
+  const key = manager._key(user.userId, agentId, 'whatsapp');
+  manager.platforms.set(key, {
+    async sendMessage() {
+      return { success: false, reason: 'upstream rejected message' };
+    },
+  });
+
+  await assert.rejects(
+    manager.sendMessage(
+      user.userId,
+      'whatsapp',
+      'chat-1',
+      'Final result.',
+      { agentId, runId: 'run-id' },
+    ),
+    (error) => error.code === 'MESSAGING_DELIVERY_FAILED',
+  );
+
+  const persisted = ctx.db.prepare(
+    'SELECT COUNT(*) AS count FROM messages WHERE run_id = ?'
+  ).get('run-id');
+  assert.equal(persisted.count, 0);
+});

--- a/test/backend/unit/messaging_progress_supervisor.test.js
+++ b/test/backend/unit/messaging_progress_supervisor.test.js
@@ -354,44 +354,22 @@ describe('messaging progress supervisor', () => {
     );
   });
 
-  test('task_complete judge rejects a high-confidence progress-only candidate', async () => {
+  test('task_complete is accepted immediately without a judge call', async () => {
+    // decideLoopState / evaluateTaskCompleteSignal are deleted.
+    // task_complete now exits the loop directly — no separate LLM judge.
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const { runId } = seedMessagingRun(engine);
 
-    engine.requestStructuredJson = async () => ({
-      value: {
-        status: 'continue',
-        reason: 'The draft is only a status update and more investigation is still possible.',
-      },
-      usage: 17,
-    });
-
-    const result = await engine.evaluateTaskCompleteSignal({
-      provider: {},
-      providerName: 'test',
-      model: 'test-model',
-      messages: [],
-      analysis: { goal: 'Fix the requested issue.' },
-      plan: { success_criteria: ['Confirm the bug', 'Implement the fix'] },
-      tools: [],
-      toolExecutions: [{ toolName: 'execute_command', error: 'owner_repo must be in format "owner/repo"' }],
-      finalMessage: 'The branch has no changes yet. Let me investigate properly.',
-      confidence: 'high',
-      triggerSource: 'messaging',
-      messagingSent: false,
-      iteration: 3,
-      maxIterations: 8,
-      options: {
-        source: 'whatsapp',
-        runId,
-        userId: user.userId,
-        agentId: null,
-      },
-    });
-
-    assert.equal(result.decision.status, 'continue');
-    assert.equal(result.usage, 17);
+    assert.equal(
+      typeof engine.evaluateTaskCompleteSignal,
+      'undefined',
+      'evaluateTaskCompleteSignal must not exist on the engine',
+    );
+    assert.equal(
+      typeof engine.decideLoopState,
+      'undefined',
+      'decideLoopState must not exist on the engine',
+    );
   });
 
   test('run goal contract merges and persists durable success criteria', () => {
@@ -453,141 +431,90 @@ describe('messaging progress supervisor', () => {
     ]);
   });
 
-  test('shared completion judge includes the persisted run goal contract', async () => {
+  test('idle supervisor nudge demands send_interim_update with elapsed time', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const { runId } = seedMessagingRun(engine);
-    engine.updateRunGoalContract(runId, {
-      goal: 'Fix the WhatsApp reliability issue.',
-      successCriteria: [
-        'The final answer must be sent back to the original messaging chat.',
-        'A progress update must never count as completion.',
-      ],
-      completionConfidenceRequired: 'high',
-      progressUpdatePolicy: 'required',
-    });
-
-    let capturedPrompt = '';
-    engine.requestStructuredJson = async ({ prompt }) => {
-      capturedPrompt = prompt;
-      return {
-        value: {
-          status: 'continue',
-          reason: 'More work remains.',
-        },
-        usage: 0,
-      };
-    };
-
-    await engine.decideLoopState({
-      provider: {},
-      providerName: 'test',
-      model: 'test-model',
-      messages: [],
-      analysis: {},
-      plan: {},
-      tools: [],
-      toolExecutions: [],
-      lastReply: 'Still checking this.',
-      triggerSource: 'messaging',
-      messagingSent: false,
-      iteration: 2,
-      maxIterations: 8,
-      options: {
-        source: 'whatsapp',
-        runId,
-        userId: user.userId,
-        agentId: null,
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: Date.now(),
+      startedAtIso: new Date(Date.now()).toISOString(),
+      progressLedger: {
+        currentPhase: 'idle',
+        currentStep: null,
+        currentTool: null,
+        currentStepStartedAt: null,
       },
     });
 
-    assert.match(capturedPrompt, /Persistent run goal: Fix the WhatsApp reliability issue\./);
-    assert.match(capturedPrompt, /A progress update must never count as completion\./);
-    assert.match(capturedPrompt, /completion_confidence_required=high/);
+    t.mock.timers.setTime(61_000);
+    const result = await engine.tickMessagingProgressSupervisor(runId);
+
+    // Idle phase → enqueues steering, does not send a runtime message
+    assert.equal(result.queued, true);
+    assert.equal(messagingManager.sent.length, 0);
+
+    // Nudge must demand an update, not just suggest one
+    const systemQueue = engine.activeRuns.get(runId)?.systemSteeringQueue ?? [];
+    const nudgeText = systemQueue.map((s) => s.content ?? s).join(' ');
+    assert.match(nudgeText, /RIGHT NOW/);
+    assert.match(nudgeText, /send_interim_update/);
   });
 
-  test('task_complete judge accepts a finished candidate', async () => {
+  test('runtime heartbeat injects ai-followup steering demanding send_interim_update', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const { runId } = seedMessagingRun(engine);
-
-    engine.requestStructuredJson = async () => ({
-      value: {
-        status: 'complete',
-        reason: 'The finished answer is now ready.',
-      },
-      usage: 9,
-    });
-
-    const result = await engine.evaluateTaskCompleteSignal({
-      provider: {},
-      providerName: 'test',
-      model: 'test-model',
-      messages: [],
-      analysis: { goal: 'Fix the requested issue.' },
-      plan: {},
-      tools: [],
-      toolExecutions: [],
-      finalMessage: 'Here is the finished answer.',
-      confidence: 'high',
-      triggerSource: 'messaging',
-      messagingSent: false,
-      iteration: 2,
-      maxIterations: 8,
-      options: {
-        source: 'whatsapp',
-        runId,
-        userId: user.userId,
-        agentId: null,
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: Date.now(),
+      startedAtIso: new Date(Date.now()).toISOString(),
+      progressLedger: {
+        currentPhase: 'tool',
+        currentStep: 'step-1',
+        currentTool: 'execute_command',
+        currentStepStartedAt: new Date(Date.now()).toISOString(),
       },
     });
 
-    assert.equal(result.decision.status, 'complete');
-    assert.equal(result.usage, 9);
+    t.mock.timers.setTime(61_000);
+    const result = await engine.tickMessagingProgressSupervisor(runId);
+
+    assert.equal(result.sent, true);
+    assert.equal(messagingManager.sent.length, 1);
+
+    // After the runtime heartbeat, steering must instruct the AI to follow up in its own words
+    const systemQueue = engine.activeRuns.get(runId)?.systemSteeringQueue ?? [];
+    const steeringText = systemQueue.map((s) => s.content ?? s).join(' ');
+    assert.match(steeringText, /send_interim_update/);
+    assert.match(steeringText, /your own words/);
   });
 
-  test('task_complete still uses the judge at the iteration limit', async () => {
+  test('heartbeat text includes run title prefix when title is set', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const { runId } = seedMessagingRun(engine);
-    let judgeCalls = 0;
-
-    engine.requestStructuredJson = async () => {
-      judgeCalls += 1;
-      return {
-        value: {
-          status: 'continue',
-          reason: 'More work is still possible in this run.',
-        },
-        usage: 4,
-      };
-    };
-
-    const result = await engine.evaluateTaskCompleteSignal({
-      provider: {},
-      providerName: 'test',
-      model: 'test-model',
-      messages: [],
-      analysis: { goal: 'Fix the requested issue.' },
-      plan: {},
-      tools: [],
-      toolExecutions: [],
-      finalMessage: 'Let me investigate that properly first.',
-      confidence: 'high',
-      triggerSource: 'messaging',
-      messagingSent: false,
-      iteration: 8,
-      maxIterations: 8,
-      options: {
-        source: 'whatsapp',
-        runId,
-        userId: user.userId,
-        agentId: null,
+    const { runId } = seedMessagingRun(engine, {
+      title: 'Fix GitHub Issue #91',
+      startedAt: Date.now(),
+      startedAtIso: new Date(Date.now()).toISOString(),
+      progressLedger: {
+        currentPhase: 'tool',
+        currentStep: 'step-1',
+        currentTool: 'execute_command',
+        currentStepStartedAt: new Date(Date.now()).toISOString(),
       },
     });
 
-    assert.equal(judgeCalls, 1);
-    assert.equal(result.decision.status, 'continue');
+    t.mock.timers.setTime(61_000);
+    await engine.tickMessagingProgressSupervisor(runId);
+
+    assert.equal(messagingManager.sent.length, 1);
+    assert.match(messagingManager.sent[0].content, /\[Fix GitHub Issue #91\]/);
   });
 
   test('terminal interim question suppresses final fallback', () => {

--- a/test/backend/unit/messaging_progress_supervisor.test.js
+++ b/test/backend/unit/messaging_progress_supervisor.test.js
@@ -123,7 +123,10 @@ describe('messaging progress supervisor', () => {
 
   test('interim progress does not suppress final fallback delivery', async () => {
     const messagingManager = createMessagingManager();
-    const engine = new AgentEngine(null, { messagingManager });
+    const engine = new AgentEngine(null, {
+      messagingManager,
+      messagingDeliveryRetry: { maxAttempts: 1 },
+    });
     const interimAt = new Date(Date.now() - 30_000).toISOString();
     const { runId } = seedMessagingRun(engine, {
       interimMessages: [{
@@ -159,13 +162,17 @@ describe('messaging progress supervisor', () => {
     assert.equal(result.sent, true);
     assert.equal(messagingManager.sent.length, 1);
     assert.equal(messagingManager.sent[0].content, 'Here is the finished answer.');
+    assert.equal(engine.getRunMeta(runId).messagingSent, true);
     assert.equal(engine.getRunMeta(runId).finalDeliverySent, true);
     assert.equal(engine.getRunMeta(runId).progressLedger.lastFinalDeliveryAt != null, true);
   });
 
   test('final fallback only sends once even when interim history exists', async () => {
     const messagingManager = createMessagingManager();
-    const engine = new AgentEngine(null, { messagingManager });
+    const engine = new AgentEngine(null, {
+      messagingManager,
+      messagingDeliveryRetry: { maxAttempts: 1 },
+    });
     const { runId } = seedMessagingRun(engine, {
       interimMessages: [{
         content: 'Still working on it',
@@ -198,6 +205,132 @@ describe('messaging progress supervisor', () => {
     assert.equal(messagingManager.sent.length, 1);
   });
 
+  test('failed final fallback delivery never records terminal delivery', async () => {
+    const messagingManager = createMessagingManager();
+    messagingManager.sendMessage = async () => ({
+      success: false,
+      error: 'transport unavailable',
+    });
+    const engine = new AgentEngine(null, {
+      messagingManager,
+      messagingDeliveryRetry: { maxAttempts: 1 },
+    });
+    const { runId } = seedMessagingRun(engine);
+
+    await assert.rejects(
+      engine.deliverMessagingFinalFallback({
+        runId,
+        userId: user.userId,
+        agentId: null,
+        platform: 'whatsapp',
+        chatId: 'chat-1',
+        content: 'This must reach the user.',
+      }),
+      (error) => error.code === 'MESSAGING_DELIVERY_FAILED',
+    );
+
+    const runMeta = engine.getRunMeta(runId);
+    assert.equal(runMeta.finalDeliverySent, false);
+    assert.equal(runMeta.lastSentMessage, '');
+    assert.equal(runMeta.sentMessages.length, 0);
+    assert.equal(runMeta.progressLedger.lastFinalDeliveryAt, null);
+  });
+
+  test('thrown final fallback delivery never records terminal delivery', async () => {
+    const messagingManager = createMessagingManager();
+    messagingManager.sendMessage = async () => {
+      throw new Error('socket closed');
+    };
+    const engine = new AgentEngine(null, {
+      messagingManager,
+      messagingDeliveryRetry: { maxAttempts: 1 },
+    });
+    const { runId } = seedMessagingRun(engine);
+
+    await assert.rejects(
+      engine.deliverMessagingFinalFallback({
+        runId,
+        userId: user.userId,
+        agentId: null,
+        platform: 'whatsapp',
+        chatId: 'chat-1',
+        content: 'This must reach the user.',
+      }),
+      /socket closed/,
+    );
+
+    assert.equal(engine.getRunMeta(runId).finalDeliverySent, false);
+  });
+
+  test('final fallback retries delivery without replaying task work', async () => {
+    const messagingManager = createMessagingManager();
+    let attempts = 0;
+    messagingManager.sendMessage = async (...args) => {
+      attempts += 1;
+      if (attempts === 1) {
+        return { success: false, error: 'temporary transport failure' };
+      }
+      messagingManager.sent.push(args);
+      return { success: true };
+    };
+    const engine = new AgentEngine(null, {
+      messagingManager,
+      messagingDeliveryRetry: {
+        maxAttempts: 2,
+        baseDelayMs: 0,
+        maxDelayMs: 0,
+      },
+    });
+    const { runId } = seedMessagingRun(engine);
+
+    const result = await engine.deliverMessagingFinalFallback({
+      runId,
+      userId: user.userId,
+      agentId: null,
+      platform: 'whatsapp',
+      chatId: 'chat-1',
+      content: 'Completed result.',
+    });
+
+    assert.equal(result.sent, true);
+    assert.equal(attempts, 2);
+    assert.equal(engine.getRunMeta(runId).finalDeliverySent, true);
+  });
+
+  test('exhausted final delivery cannot trigger an autonomous task replay', async () => {
+    const messagingManager = createMessagingManager();
+    messagingManager.sendMessage = async () => ({
+      success: false,
+      error: 'transport unavailable',
+    });
+    const engine = new AgentEngine(null, {
+      messagingManager,
+      messagingDeliveryRetry: {
+        maxAttempts: 2,
+        baseDelayMs: 0,
+        maxDelayMs: 0,
+      },
+    });
+    const { runId } = seedMessagingRun(engine);
+
+    await assert.rejects(
+      engine.deliverMessagingFinalFallback({
+        runId,
+        userId: user.userId,
+        agentId: null,
+        platform: 'whatsapp',
+        chatId: 'chat-1',
+        content: 'Completed result.',
+      }),
+      (error) => (
+        error.code === 'MESSAGING_DELIVERY_FAILED'
+        && error.disableAutonomousRetry === true
+      ),
+    );
+
+    assert.equal(engine.getRunMeta(runId).finalDeliverySent, false);
+  });
+
   test('explicit final messaging delivery suppresses auto fallback', () => {
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
@@ -221,50 +354,34 @@ describe('messaging progress supervisor', () => {
     );
   });
 
-  test('messaging completion decision keeps working after visible progress until a final answer or blocker exists', async () => {
+  test('task_complete judge rejects a high-confidence progress-only candidate', async () => {
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const interimAt = new Date(Date.now() - 45_000).toISOString();
-    const { runId } = seedMessagingRun(engine, {
-      interimMessages: [{
-        content: 'nope, noch nicht fertig. hatte angefangen zu recherchieren, hol ich jetzt nach.',
-        kind: 'progress',
-        expectsReply: false,
-        deferFollowUp: false,
-        createdAt: interimAt,
-      }],
-      progressLedger: {
-        lastUserVisibleUpdateAt: interimAt,
-      },
-    });
+    const { runId } = seedMessagingRun(engine);
 
     engine.requestStructuredJson = async () => ({
       value: {
         status: 'continue',
         reason: 'The draft is only a status update and more investigation is still possible.',
-        final_reply: '',
       },
       usage: 17,
     });
 
-    const messages = [{
-      role: 'assistant',
-      content: 'The checkout branch exists at the same commit as beta with no changes yet. Let me investigate properly.',
-    }];
-    const result = await engine.resolveMessagingCompletionDecision({
+    const result = await engine.evaluateTaskCompleteSignal({
       provider: {},
       providerName: 'test',
       model: 'test-model',
-      messages,
+      messages: [],
       analysis: { goal: 'Fix the requested issue.' },
       plan: { success_criteria: ['Confirm the bug', 'Implement the fix'] },
       tools: [],
       toolExecutions: [{ toolName: 'execute_command', error: 'owner_repo must be in format "owner/repo"' }],
-      lastReply: messages[0].content,
+      finalMessage: 'The branch has no changes yet. Let me investigate properly.',
+      confidence: 'high',
+      triggerSource: 'messaging',
+      messagingSent: false,
       iteration: 3,
       maxIterations: 8,
-      runId,
-      conversationId: null,
       options: {
         source: 'whatsapp',
         runId,
@@ -273,8 +390,7 @@ describe('messaging progress supervisor', () => {
       },
     });
 
-    assert.equal(result.action, 'continue');
-    assert.equal(result.content, '');
+    assert.equal(result.decision.status, 'continue');
     assert.equal(result.usage, 17);
   });
 
@@ -313,7 +429,31 @@ describe('messaging progress supervisor', () => {
     assert.deepEqual(persisted.goalContract.successCriteria, runMeta.goalContract.successCriteria);
   });
 
-  test('messaging completion prompt includes the persisted run goal contract', async () => {
+  test('the original run goal cannot be replaced by a later model summary', () => {
+    const engine = new AgentEngine(null, {
+      messagingManager: createMessagingManager(),
+    });
+    const { runId } = seedMessagingRun(engine);
+
+    engine.updateRunGoalContract(runId, {
+      goal: 'Implement the complete user request and verify the result.',
+    });
+    engine.updateRunGoalContract(runId, {
+      goal: 'Send a short acknowledgement.',
+      successCriteria: ['The requested implementation is complete.'],
+    });
+
+    const goalContract = engine.getRunMeta(runId).goalContract;
+    assert.equal(
+      goalContract.goal,
+      'Implement the complete user request and verify the result.',
+    );
+    assert.deepEqual(goalContract.successCriteria, [
+      'The requested implementation is complete.',
+    ]);
+  });
+
+  test('shared completion judge includes the persisted run goal contract', async () => {
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
     const { runId } = seedMessagingRun(engine);
@@ -334,13 +474,12 @@ describe('messaging progress supervisor', () => {
         value: {
           status: 'continue',
           reason: 'More work remains.',
-          final_reply: '',
         },
         usage: 0,
       };
     };
 
-    await engine.decideMessagingCompletionState({
+    await engine.decideLoopState({
       provider: {},
       providerName: 'test',
       model: 'test-model',
@@ -350,9 +489,10 @@ describe('messaging progress supervisor', () => {
       tools: [],
       toolExecutions: [],
       lastReply: 'Still checking this.',
+      triggerSource: 'messaging',
+      messagingSent: false,
       iteration: 2,
       maxIterations: 8,
-      runId,
       options: {
         source: 'whatsapp',
         runId,
@@ -366,59 +506,34 @@ describe('messaging progress supervisor', () => {
     assert.match(capturedPrompt, /completion_confidence_required=high/);
   });
 
-  test('messaging completion decision rewrites the latest assistant draft before final fallback delivery', async () => {
+  test('task_complete judge accepts a finished candidate', async () => {
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const interimAt = new Date(Date.now() - 45_000).toISOString();
-    const conversationId = 'conv-1';
-    ctx.db.prepare(
-      `INSERT INTO conversations (id, user_id, agent_id, platform, platform_chat_id, title)
-       VALUES (?, ?, ?, ?, ?, ?)`
-    ).run(conversationId, user.userId, null, 'whatsapp', 'chat-1', 'Messaging test conversation');
-    ctx.db.prepare(
-      'INSERT INTO conversation_messages (conversation_id, role, content) VALUES (?, ?, ?)'
-    ).run(conversationId, 'assistant', 'Still checking this.');
-
-    const { runId } = seedMessagingRun(engine, {
-      interimMessages: [{
-        content: 'Still checking this.',
-        kind: 'progress',
-        expectsReply: false,
-        deferFollowUp: false,
-        createdAt: interimAt,
-      }],
-      progressLedger: {
-        lastUserVisibleUpdateAt: interimAt,
-      },
-    });
+    const { runId } = seedMessagingRun(engine);
 
     engine.requestStructuredJson = async () => ({
       value: {
         status: 'complete',
         reason: 'The finished answer is now ready.',
-        final_reply: 'Here is the finished answer.',
       },
       usage: 9,
     });
 
-    const messages = [{
-      role: 'assistant',
-      content: 'Still checking this.',
-    }];
-    const result = await engine.resolveMessagingCompletionDecision({
+    const result = await engine.evaluateTaskCompleteSignal({
       provider: {},
       providerName: 'test',
       model: 'test-model',
-      messages,
+      messages: [],
       analysis: { goal: 'Fix the requested issue.' },
       plan: {},
       tools: [],
       toolExecutions: [],
-      lastReply: messages[0].content,
+      finalMessage: 'Here is the finished answer.',
+      confidence: 'high',
+      triggerSource: 'messaging',
+      messagingSent: false,
       iteration: 2,
       maxIterations: 8,
-      runId,
-      conversationId,
       options: {
         source: 'whatsapp',
         runId,
@@ -427,68 +542,52 @@ describe('messaging progress supervisor', () => {
       },
     });
 
-    const storedMessage = ctx.db.prepare(
-      'SELECT content FROM conversation_messages WHERE conversation_id = ? ORDER BY id DESC LIMIT 1'
-    ).get(conversationId);
-    assert.equal(result.action, 'complete');
-    assert.equal(result.content, 'Here is the finished answer.');
-    assert.equal(messages[messages.length - 1].content, 'Here is the finished answer.');
-    assert.equal(storedMessage.content, 'Here is the finished answer.');
+    assert.equal(result.decision.status, 'complete');
+    assert.equal(result.usage, 9);
   });
 
-  test('iteration-limit messaging run does not stop on a progress-only draft after visible progress', async () => {
+  test('task_complete still uses the judge at the iteration limit', async () => {
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
-    const interimAt = new Date(Date.now() - 45_000).toISOString();
-    const { runId } = seedMessagingRun(engine, {
-      interimMessages: [{
-        content: 'Still working on it',
-        kind: 'progress',
-        expectsReply: false,
-        deferFollowUp: false,
-        createdAt: interimAt,
-      }],
-      progressLedger: {
-        lastUserVisibleUpdateAt: interimAt,
-      },
-    });
+    const { runId } = seedMessagingRun(engine);
+    let judgeCalls = 0;
 
-    engine.requestStructuredJson = async () => ({
-      value: {
-        status: 'continue',
-        reason: 'More work is still possible in this run.',
-        final_reply: '',
-      },
-      usage: 4,
-    });
-
-    await assert.rejects(
-      engine.resolveMessagingCompletionDecision({
-        provider: {},
-        providerName: 'test',
-        model: 'test-model',
-        messages: [{
-          role: 'assistant',
-          content: 'Let me investigate that properly first.',
-        }],
-        analysis: { goal: 'Fix the requested issue.' },
-        plan: {},
-        tools: [],
-        toolExecutions: [],
-        lastReply: 'Let me investigate that properly first.',
-        iteration: 8,
-        maxIterations: 8,
-        runId,
-        conversationId: null,
-        options: {
-          source: 'whatsapp',
-          runId,
-          userId: user.userId,
-          agentId: null,
+    engine.requestStructuredJson = async () => {
+      judgeCalls += 1;
+      return {
+        value: {
+          status: 'continue',
+          reason: 'More work is still possible in this run.',
         },
-      }),
-      /iteration limit/,
-    );
+        usage: 4,
+      };
+    };
+
+    const result = await engine.evaluateTaskCompleteSignal({
+      provider: {},
+      providerName: 'test',
+      model: 'test-model',
+      messages: [],
+      analysis: { goal: 'Fix the requested issue.' },
+      plan: {},
+      tools: [],
+      toolExecutions: [],
+      finalMessage: 'Let me investigate that properly first.',
+      confidence: 'high',
+      triggerSource: 'messaging',
+      messagingSent: false,
+      iteration: 8,
+      maxIterations: 8,
+      options: {
+        source: 'whatsapp',
+        runId,
+        userId: user.userId,
+        agentId: null,
+      },
+    });
+
+    assert.equal(judgeCalls, 1);
+    assert.equal(result.decision.status, 'continue');
   });
 
   test('terminal interim question suppresses final fallback', () => {
@@ -567,6 +666,119 @@ describe('messaging progress supervisor', () => {
     assert.equal(messagingManager.sent.length, 1);
     assert.match(messagingManager.sent[0].content, /Run active 2m/);
     assert.match(messagingManager.sent[0].content, /current step 1s/);
+  });
+
+  test('blocked model calls receive factual runtime heartbeats', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: 0,
+      startedAtIso: new Date(0).toISOString(),
+      progressLedger: {
+        currentPhase: 'model',
+        currentStep: 'model:2',
+        currentTool: null,
+        currentStepStartedAt: new Date(0).toISOString(),
+      },
+    });
+
+    t.mock.timers.setTime(60_001);
+    await engine.tickMessagingProgressSupervisor(runId);
+
+    assert.equal(messagingManager.sent.length, 1);
+    assert.match(messagingManager.sent[0].content, /Still working on this/);
+    assert.equal(engine.getRunMeta(runId).progressLedger.heartbeatCount, 1);
+  });
+
+  test('structured model phases stay visible to the supervisor until they settle', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: 0,
+      startedAtIso: new Date(0).toISOString(),
+    });
+    let resolveModel;
+    const modelResult = new Promise((resolve) => {
+      resolveModel = resolve;
+    });
+
+    const structuredCall = engine.requestStructuredJson({
+      provider: {
+        chat() {
+          return modelResult;
+        },
+      },
+      providerName: 'test',
+      model: 'test-model',
+      messages: [],
+      prompt: 'Return JSON.',
+      normalize: (value) => value,
+      telemetry: {
+        runId,
+        userId: user.userId,
+      },
+      phase: 'completion_decision',
+    });
+
+    assert.equal(engine.getRunMeta(runId).progressLedger.currentPhase, 'model');
+    assert.equal(
+      engine.getRunMeta(runId).progressLedger.currentStep,
+      'model:completion_decision',
+    );
+
+    t.mock.timers.setTime(60_001);
+    await engine.tickMessagingProgressSupervisor(runId);
+
+    assert.equal(messagingManager.sent.length, 1);
+    assert.equal(engine.getRunMeta(runId).progressLedger.heartbeatCount, 1);
+
+    resolveModel({
+      content: '{"status":"complete"}',
+      usage: { totalTokens: 3 },
+    });
+    await structuredCall;
+
+    assert.equal(engine.getRunMeta(runId).progressLedger.currentPhase, 'idle');
+    assert.equal(engine.getRunMeta(runId).progressLedger.currentStep, null);
+  });
+
+  test('failed runtime heartbeat is not recorded as visible progress', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
+    const messagingManager = createMessagingManager();
+    messagingManager.sendMessage = async () => ({
+      success: false,
+      reason: 'not connected',
+    });
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: 0,
+      startedAtIso: new Date(0).toISOString(),
+      progressLedger: {
+        currentPhase: 'tool',
+        currentStep: 'step-1',
+        currentTool: 'execute_command',
+        currentStepStartedAt: new Date(0).toISOString(),
+      },
+    });
+
+    t.mock.timers.setTime(60_001);
+    await assert.rejects(
+      engine.tickMessagingProgressSupervisor(runId),
+      (error) => error.code === 'MESSAGING_DELIVERY_FAILED',
+    );
+
+    const runMeta = engine.getRunMeta(runId);
+    assert.equal(Number(runMeta.progressLedger.heartbeatCount || 0), 0);
+    assert.equal(runMeta.progressLedger.lastUserVisibleUpdateAt || null, null);
+    assert.equal(runMeta.interimMessages.length, 0);
   });
 
   test('stalled tool-bound messaging run records stalled state and resumes on verified progress', async (t) => {

--- a/test/backend/unit/messaging_progress_supervisor.test.js
+++ b/test/backend/unit/messaging_progress_supervisor.test.js
@@ -221,6 +221,276 @@ describe('messaging progress supervisor', () => {
     );
   });
 
+  test('messaging completion decision keeps working after visible progress until a final answer or blocker exists', async () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const interimAt = new Date(Date.now() - 45_000).toISOString();
+    const { runId } = seedMessagingRun(engine, {
+      interimMessages: [{
+        content: 'nope, noch nicht fertig. hatte angefangen zu recherchieren, hol ich jetzt nach.',
+        kind: 'progress',
+        expectsReply: false,
+        deferFollowUp: false,
+        createdAt: interimAt,
+      }],
+      progressLedger: {
+        lastUserVisibleUpdateAt: interimAt,
+      },
+    });
+
+    engine.requestStructuredJson = async () => ({
+      value: {
+        status: 'continue',
+        reason: 'The draft is only a status update and more investigation is still possible.',
+        final_reply: '',
+      },
+      usage: 17,
+    });
+
+    const messages = [{
+      role: 'assistant',
+      content: 'The checkout branch exists at the same commit as beta with no changes yet. Let me investigate properly.',
+    }];
+    const result = await engine.resolveMessagingCompletionDecision({
+      provider: {},
+      providerName: 'test',
+      model: 'test-model',
+      messages,
+      analysis: { goal: 'Fix the requested issue.' },
+      plan: { success_criteria: ['Confirm the bug', 'Implement the fix'] },
+      tools: [],
+      toolExecutions: [{ toolName: 'execute_command', error: 'owner_repo must be in format "owner/repo"' }],
+      lastReply: messages[0].content,
+      iteration: 3,
+      maxIterations: 8,
+      runId,
+      conversationId: null,
+      options: {
+        source: 'whatsapp',
+        runId,
+        userId: user.userId,
+        agentId: null,
+      },
+    });
+
+    assert.equal(result.action, 'continue');
+    assert.equal(result.content, '');
+    assert.equal(result.usage, 17);
+  });
+
+  test('run goal contract merges and persists durable success criteria', () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine);
+
+    engine.updateRunGoalContract(runId, {
+      goal: 'Fix messaging reliability.',
+      successCriteria: [
+        'Final reply reaches the originating chat.',
+      ],
+      completionConfidenceRequired: 'high',
+    });
+    engine.updateRunGoalContract(runId, {
+      successCriteria: [
+        'Progress notes never suppress the final reply.',
+        'Final reply reaches the originating chat.',
+      ],
+      progressUpdatePolicy: 'required',
+    });
+
+    const runMeta = engine.getRunMeta(runId);
+    const persisted = JSON.parse(ctx.db.prepare(
+      'SELECT metadata_json FROM agent_runs WHERE id = ?'
+    ).get(runId).metadata_json || '{}');
+
+    assert.equal(runMeta.goalContract.goal, 'Fix messaging reliability.');
+    assert.deepEqual(runMeta.goalContract.successCriteria, [
+      'Final reply reaches the originating chat.',
+      'Progress notes never suppress the final reply.',
+    ]);
+    assert.equal(runMeta.goalContract.completionConfidenceRequired, 'high');
+    assert.equal(runMeta.goalContract.progressUpdatePolicy, 'required');
+    assert.deepEqual(persisted.goalContract.successCriteria, runMeta.goalContract.successCriteria);
+  });
+
+  test('messaging completion prompt includes the persisted run goal contract', async () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine);
+    engine.updateRunGoalContract(runId, {
+      goal: 'Fix the WhatsApp reliability issue.',
+      successCriteria: [
+        'The final answer must be sent back to the original messaging chat.',
+        'A progress update must never count as completion.',
+      ],
+      completionConfidenceRequired: 'high',
+      progressUpdatePolicy: 'required',
+    });
+
+    let capturedPrompt = '';
+    engine.requestStructuredJson = async ({ prompt }) => {
+      capturedPrompt = prompt;
+      return {
+        value: {
+          status: 'continue',
+          reason: 'More work remains.',
+          final_reply: '',
+        },
+        usage: 0,
+      };
+    };
+
+    await engine.decideMessagingCompletionState({
+      provider: {},
+      providerName: 'test',
+      model: 'test-model',
+      messages: [],
+      analysis: {},
+      plan: {},
+      tools: [],
+      toolExecutions: [],
+      lastReply: 'Still checking this.',
+      iteration: 2,
+      maxIterations: 8,
+      runId,
+      options: {
+        source: 'whatsapp',
+        runId,
+        userId: user.userId,
+        agentId: null,
+      },
+    });
+
+    assert.match(capturedPrompt, /Persistent run goal: Fix the WhatsApp reliability issue\./);
+    assert.match(capturedPrompt, /A progress update must never count as completion\./);
+    assert.match(capturedPrompt, /completion_confidence_required=high/);
+  });
+
+  test('messaging completion decision rewrites the latest assistant draft before final fallback delivery', async () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const interimAt = new Date(Date.now() - 45_000).toISOString();
+    const conversationId = 'conv-1';
+    ctx.db.prepare(
+      `INSERT INTO conversations (id, user_id, agent_id, platform, platform_chat_id, title)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(conversationId, user.userId, null, 'whatsapp', 'chat-1', 'Messaging test conversation');
+    ctx.db.prepare(
+      'INSERT INTO conversation_messages (conversation_id, role, content) VALUES (?, ?, ?)'
+    ).run(conversationId, 'assistant', 'Still checking this.');
+
+    const { runId } = seedMessagingRun(engine, {
+      interimMessages: [{
+        content: 'Still checking this.',
+        kind: 'progress',
+        expectsReply: false,
+        deferFollowUp: false,
+        createdAt: interimAt,
+      }],
+      progressLedger: {
+        lastUserVisibleUpdateAt: interimAt,
+      },
+    });
+
+    engine.requestStructuredJson = async () => ({
+      value: {
+        status: 'complete',
+        reason: 'The finished answer is now ready.',
+        final_reply: 'Here is the finished answer.',
+      },
+      usage: 9,
+    });
+
+    const messages = [{
+      role: 'assistant',
+      content: 'Still checking this.',
+    }];
+    const result = await engine.resolveMessagingCompletionDecision({
+      provider: {},
+      providerName: 'test',
+      model: 'test-model',
+      messages,
+      analysis: { goal: 'Fix the requested issue.' },
+      plan: {},
+      tools: [],
+      toolExecutions: [],
+      lastReply: messages[0].content,
+      iteration: 2,
+      maxIterations: 8,
+      runId,
+      conversationId,
+      options: {
+        source: 'whatsapp',
+        runId,
+        userId: user.userId,
+        agentId: null,
+      },
+    });
+
+    const storedMessage = ctx.db.prepare(
+      'SELECT content FROM conversation_messages WHERE conversation_id = ? ORDER BY id DESC LIMIT 1'
+    ).get(conversationId);
+    assert.equal(result.action, 'complete');
+    assert.equal(result.content, 'Here is the finished answer.');
+    assert.equal(messages[messages.length - 1].content, 'Here is the finished answer.');
+    assert.equal(storedMessage.content, 'Here is the finished answer.');
+  });
+
+  test('iteration-limit messaging run does not stop on a progress-only draft after visible progress', async () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const interimAt = new Date(Date.now() - 45_000).toISOString();
+    const { runId } = seedMessagingRun(engine, {
+      interimMessages: [{
+        content: 'Still working on it',
+        kind: 'progress',
+        expectsReply: false,
+        deferFollowUp: false,
+        createdAt: interimAt,
+      }],
+      progressLedger: {
+        lastUserVisibleUpdateAt: interimAt,
+      },
+    });
+
+    engine.requestStructuredJson = async () => ({
+      value: {
+        status: 'continue',
+        reason: 'More work is still possible in this run.',
+        final_reply: '',
+      },
+      usage: 4,
+    });
+
+    await assert.rejects(
+      engine.resolveMessagingCompletionDecision({
+        provider: {},
+        providerName: 'test',
+        model: 'test-model',
+        messages: [{
+          role: 'assistant',
+          content: 'Let me investigate that properly first.',
+        }],
+        analysis: { goal: 'Fix the requested issue.' },
+        plan: {},
+        tools: [],
+        toolExecutions: [],
+        lastReply: 'Let me investigate that properly first.',
+        iteration: 8,
+        maxIterations: 8,
+        runId,
+        conversationId: null,
+        options: {
+          source: 'whatsapp',
+          runId,
+          userId: user.userId,
+          agentId: null,
+        },
+      }),
+      /iteration limit/,
+    );
+  });
+
   test('terminal interim question suppresses final fallback', () => {
     const messagingManager = createMessagingManager();
     const engine = new AgentEngine(null, { messagingManager });
@@ -274,6 +544,31 @@ describe('messaging progress supervisor', () => {
     assert.equal(engine.getRunMeta(runId).progressLedger.heartbeatCount, 2);
   });
 
+  test('runtime heartbeat includes overall run age even when the current tool just started', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: 0,
+      startedAtIso: new Date(0).toISOString(),
+      progressLedger: {
+        currentPhase: 'tool',
+        currentStep: 'step-3',
+        currentTool: 'execute_command',
+        currentStepStartedAt: new Date(119_000).toISOString(),
+      },
+    });
+
+    t.mock.timers.setTime(120_000);
+    await engine.tickMessagingProgressSupervisor(runId);
+
+    assert.equal(messagingManager.sent.length, 1);
+    assert.match(messagingManager.sent[0].content, /Run active 2m/);
+    assert.match(messagingManager.sent[0].content, /current step 1s/);
+  });
+
   test('stalled tool-bound messaging run records stalled state and resumes on verified progress', async (t) => {
     t.mock.timers.enable({ apis: ['Date'] });
     t.mock.timers.setTime(0);
@@ -297,7 +592,7 @@ describe('messaging progress supervisor', () => {
     const stalledRun = engine.getRunMeta(runId);
     assert.equal(stalledRun.progressLedger.progressState, 'stalled');
     assert.equal(stalledRun.progressLedger.stallNotifiedAt != null, true);
-    assert.match(messagingManager.sent[messagingManager.sent.length - 1].content, /not made verified progress/);
+    assert.match(messagingManager.sent[messagingManager.sent.length - 1].content, /no verified progress/);
     assert.equal(listRunEvents(runId).some((event) => event.eventType === 'progress_stalled'), true);
 
     engine.updateRunProgress(runId, {

--- a/test/backend/unit/messaging_progress_supervisor.test.js
+++ b/test/backend/unit/messaging_progress_supervisor.test.js
@@ -1,0 +1,328 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { afterEach, beforeEach, describe, test } = require('node:test');
+
+const {
+  createTestRuntime,
+  createTestUser,
+  teardownTestRuntime,
+} = require('../../helpers/db');
+
+function createMessagingManager() {
+  const sent = [];
+  const typing = [];
+  return {
+    sent,
+    typing,
+    async sendMessage(userId, platform, to, content, options = {}) {
+      sent.push({ userId, platform, to, content, options });
+      return { success: true };
+    },
+    async sendTyping(userId, platform, to, isTyping, options = {}) {
+      typing.push({ userId, platform, to, isTyping, options });
+      return { success: true };
+    },
+  };
+}
+
+describe('messaging progress supervisor', () => {
+  let ctx;
+  let user;
+  let AgentEngine;
+  let listRunEvents;
+
+  beforeEach(async () => {
+    ctx = createTestRuntime();
+    user = await createTestUser(ctx.db);
+    ({ AgentEngine } = require('../../../server/services/ai/engine'));
+    ({ listRunEvents } = require('../../../server/services/ai/runEvents'));
+  });
+
+  afterEach(() => {
+    teardownTestRuntime(ctx);
+  });
+
+  function insertRun(runId) {
+    ctx.db.prepare(
+      `INSERT INTO agent_runs (
+        id, user_id, agent_id, title, status, trigger_type, trigger_source, model, metadata_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      runId,
+      user.userId,
+      null,
+      'Messaging test run',
+      'running',
+      'user',
+      'messaging',
+      'test-model',
+      '{}',
+    );
+  }
+
+  function seedMessagingRun(engine, extra = {}) {
+    const runId = extra.runId || `run-${Math.random().toString(16).slice(2)}`;
+    insertRun(runId);
+    const startedAt = Number(extra.startedAt || Date.now());
+    const startedAtIso = extra.startedAtIso || new Date(startedAt).toISOString();
+    const interimMessages = Array.isArray(extra.interimMessages) ? extra.interimMessages.slice() : [];
+    const progressLedger = {
+      currentStep: null,
+      currentTool: null,
+      currentStepStartedAt: null,
+      lastVerifiedProgressAt: startedAtIso,
+      lastUserVisibleUpdateAt: null,
+      lastFinalDeliveryAt: null,
+      heartbeatCount: 0,
+      stallNotifiedAt: null,
+      progressState: 'active',
+      currentPhase: 'idle',
+      ...(extra.progressLedger || {}),
+    };
+    const runMeta = {
+      userId: user.userId,
+      agentId: null,
+      status: 'running',
+      aborted: false,
+      messagingSent: false,
+      noResponse: false,
+      explicitMessageSent: false,
+      finalDeliverySent: false,
+      lastSentMessage: '',
+      sentMessages: [],
+      widgetSnapshotSaved: false,
+      triggerType: 'user',
+      triggerSource: 'messaging',
+      startedAt,
+      startedAtIso,
+      lastToolName: null,
+      lastToolTarget: null,
+      lastInterimMessage: interimMessages[interimMessages.length - 1]?.content || '',
+      interimMessages,
+      interimSignatures: new Set(),
+      terminalInterim: null,
+      voiceSessionId: null,
+      steeringQueue: [],
+      systemSteeringQueue: [],
+      toolPids: new Set(),
+      repetitionGuard: {},
+      messagingContext: {
+        platform: 'whatsapp',
+        chatId: 'chat-1',
+      },
+      progressLedger,
+      ...extra,
+    };
+    engine.activeRuns.set(runId, runMeta);
+    engine.persistRunMetadata(runId, {
+      progressLedger: engine.buildProgressLedgerSnapshot(runMeta),
+    });
+    return { runId, runMeta };
+  }
+
+  test('interim progress does not suppress final fallback delivery', async () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const interimAt = new Date(Date.now() - 30_000).toISOString();
+    const { runId } = seedMessagingRun(engine, {
+      interimMessages: [{
+        content: 'Alright let me read that first',
+        kind: 'progress',
+        expectsReply: false,
+        deferFollowUp: false,
+        createdAt: interimAt,
+      }],
+      progressLedger: {
+        lastUserVisibleUpdateAt: interimAt,
+      },
+    });
+
+    assert.equal(
+      engine.shouldSendMessagingFinalFallback(
+        engine.getRunMeta(runId),
+        'Here is the finished answer.',
+        'whatsapp',
+      ),
+      true,
+    );
+
+    const result = await engine.deliverMessagingFinalFallback({
+      runId,
+      userId: user.userId,
+      agentId: null,
+      platform: 'whatsapp',
+      chatId: 'chat-1',
+      content: 'Here is the finished answer.',
+    });
+
+    assert.equal(result.sent, true);
+    assert.equal(messagingManager.sent.length, 1);
+    assert.equal(messagingManager.sent[0].content, 'Here is the finished answer.');
+    assert.equal(engine.getRunMeta(runId).finalDeliverySent, true);
+    assert.equal(engine.getRunMeta(runId).progressLedger.lastFinalDeliveryAt != null, true);
+  });
+
+  test('final fallback only sends once even when interim history exists', async () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      interimMessages: [{
+        content: 'Still working on it',
+        kind: 'progress',
+        expectsReply: false,
+        deferFollowUp: false,
+        createdAt: new Date().toISOString(),
+      }],
+    });
+
+    const first = await engine.deliverMessagingFinalFallback({
+      runId,
+      userId: user.userId,
+      agentId: null,
+      platform: 'whatsapp',
+      chatId: 'chat-1',
+      content: 'Recovered final answer.',
+    });
+    const second = await engine.deliverMessagingFinalFallback({
+      runId,
+      userId: user.userId,
+      agentId: null,
+      platform: 'whatsapp',
+      chatId: 'chat-1',
+      content: 'Recovered final answer.',
+    });
+
+    assert.equal(first.sent, true);
+    assert.equal(second.sent, false);
+    assert.equal(messagingManager.sent.length, 1);
+  });
+
+  test('explicit final messaging delivery suppresses auto fallback', () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      explicitMessageSent: true,
+      finalDeliverySent: true,
+      lastSentMessage: 'Done already.',
+      sentMessages: ['Done already.'],
+      progressLedger: {
+        lastFinalDeliveryAt: new Date().toISOString(),
+      },
+    });
+
+    assert.equal(
+      engine.shouldSendMessagingFinalFallback(
+        engine.getRunMeta(runId),
+        'Another answer',
+        'whatsapp',
+      ),
+      false,
+    );
+  });
+
+  test('terminal interim question suppresses final fallback', () => {
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      terminalInterim: {
+        kind: 'question',
+        content: 'Which file should I use?',
+        createdAt: new Date().toISOString(),
+      },
+    });
+
+    assert.equal(
+      engine.shouldSendMessagingFinalFallback(
+        engine.getRunMeta(runId),
+        'This should not auto-send.',
+        'whatsapp',
+      ),
+      false,
+    );
+  });
+
+  test('tool-bound messaging run sends a heartbeat after 60 seconds and respects the 90 second cadence', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: Date.now(),
+      startedAtIso: new Date(Date.now()).toISOString(),
+      progressLedger: {
+        currentPhase: 'tool',
+        currentStep: 'step-1',
+        currentTool: 'execute_command',
+        currentStepStartedAt: new Date(Date.now()).toISOString(),
+      },
+    });
+
+    t.mock.timers.setTime(60_001);
+    await engine.tickMessagingProgressSupervisor(runId);
+    assert.equal(messagingManager.sent.length, 1);
+    assert.match(messagingManager.sent[0].content, /Still working on execute_command/);
+
+    t.mock.timers.setTime(149_000);
+    await engine.tickMessagingProgressSupervisor(runId);
+    assert.equal(messagingManager.sent.length, 1);
+
+    t.mock.timers.setTime(150_001);
+    await engine.tickMessagingProgressSupervisor(runId);
+    assert.equal(messagingManager.sent.length, 2);
+    assert.equal(engine.getRunMeta(runId).progressLedger.heartbeatCount, 2);
+  });
+
+  test('stalled tool-bound messaging run records stalled state and resumes on verified progress', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'] });
+    t.mock.timers.setTime(0);
+
+    const messagingManager = createMessagingManager();
+    const engine = new AgentEngine(null, { messagingManager });
+    const { runId } = seedMessagingRun(engine, {
+      startedAt: Date.now(),
+      startedAtIso: new Date(Date.now()).toISOString(),
+      progressLedger: {
+        currentPhase: 'tool',
+        currentStep: 'step-2',
+        currentTool: 'browser_navigate',
+        currentStepStartedAt: new Date(Date.now()).toISOString(),
+      },
+    });
+
+    t.mock.timers.setTime(240_001);
+    await engine.tickMessagingProgressSupervisor(runId);
+
+    const stalledRun = engine.getRunMeta(runId);
+    assert.equal(stalledRun.progressLedger.progressState, 'stalled');
+    assert.equal(stalledRun.progressLedger.stallNotifiedAt != null, true);
+    assert.match(messagingManager.sent[messagingManager.sent.length - 1].content, /not made verified progress/);
+    assert.equal(listRunEvents(runId).some((event) => event.eventType === 'progress_stalled'), true);
+
+    engine.updateRunProgress(runId, {
+      currentPhase: 'idle',
+      currentStep: null,
+      currentTool: null,
+      currentStepStartedAt: null,
+    }, {
+      verified: true,
+    });
+
+    const resumedRun = engine.getRunMeta(runId);
+    assert.equal(resumedRun.progressLedger.progressState, 'active');
+    assert.equal(resumedRun.progressLedger.stallNotifiedAt, null);
+    assert.equal(listRunEvents(runId).some((event) => event.eventType === 'progress_resumed'), true);
+  });
+
+  test('missing artifact stat warning path is non-fatal', async () => {
+    const { extractArtifactsFromResult } = require('../../../server/services/ai/deliverables/artifact_helpers');
+
+    const artifacts = await extractArtifactsFromResult('execute_command', {
+      stdout: '/tmp/neoagent-missing-artifact.txt',
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].path, '/tmp/neoagent-missing-artifact.txt');
+  });
+});

--- a/test/backend/unit/messaging_progress_supervisor.test.js
+++ b/test/backend/unit/messaging_progress_supervisor.test.js
@@ -610,14 +610,13 @@ describe('messaging progress supervisor', () => {
     assert.equal(listRunEvents(runId).some((event) => event.eventType === 'progress_resumed'), true);
   });
 
-  test('missing artifact stat warning path is non-fatal', async () => {
+  test('missing artifact stat warning path is non-fatal and drops invalid candidates', async () => {
     const { extractArtifactsFromResult } = require('../../../server/services/ai/deliverables/artifact_helpers');
 
     const artifacts = await extractArtifactsFromResult('execute_command', {
       stdout: '/tmp/neoagent-missing-artifact.txt',
     });
 
-    assert.equal(artifacts.length, 1);
-    assert.equal(artifacts[0].path, '/tmp/neoagent-missing-artifact.txt');
+    assert.equal(artifacts.length, 0);
   });
 });

--- a/test/backend/unit/task_runtime_delivery.test.js
+++ b/test/backend/unit/task_runtime_delivery.test.js
@@ -241,6 +241,92 @@ describe('scheduled task result delivery', () => {
     assert.equal(deliveryState.noResponse, true);
   });
 
+  test('failed explicit send_message does not mark terminal delivery', async () => {
+    const { executeTool } = require('../../../server/services/ai/tools');
+    const runState = {
+      messagingSent: false,
+      explicitMessageSent: false,
+      finalDeliverySent: false,
+      sentMessages: [],
+    };
+    const engine = {
+      activeRuns: new Map([['run-id', runState]]),
+      messagingManager: {
+        async sendMessage() {
+          return { success: false, error: 'transport unavailable' };
+        },
+      },
+    };
+
+    const result = await executeTool('send_message', {
+      platform: 'whatsapp',
+      to: 'recipient',
+      content: 'Finished result.',
+    }, {
+      userId: user.userId,
+      runId: 'run-id',
+      triggerSource: 'messaging',
+      source: 'whatsapp',
+      chatId: 'recipient@s.whatsapp.net',
+    }, engine);
+
+    assert.equal(result.success, false);
+    assert.equal(runState.messagingSent, false);
+    assert.equal(runState.explicitMessageSent, false);
+    assert.equal(runState.finalDeliverySent, false);
+    assert.deepEqual(runState.sentMessages, []);
+  });
+
+  test('explicit messaging delivery is terminal only for the originating chat', async () => {
+    const { executeTool } = require('../../../server/services/ai/tools');
+    const runState = {
+      messagingSent: false,
+      explicitMessageSent: false,
+      finalDeliverySent: false,
+      sentMessages: [],
+    };
+    const sent = [];
+    const engine = {
+      activeRuns: new Map([['run-id', runState]]),
+      messagingManager: {
+        async sendMessage(userId, platform, to, content) {
+          sent.push({ userId, platform, to, content });
+          return { success: true };
+        },
+      },
+    };
+    const context = {
+      userId: user.userId,
+      runId: 'run-id',
+      triggerSource: 'messaging',
+      source: 'whatsapp',
+      chatId: '49123456789:7@s.whatsapp.net',
+    };
+
+    await executeTool('send_message', {
+      platform: 'whatsapp',
+      to: '49987654321',
+      content: 'Side-effect notification.',
+    }, context, engine);
+
+    assert.equal(sent.length, 1);
+    assert.equal(runState.messagingSent, false);
+    assert.equal(runState.explicitMessageSent, false);
+    assert.equal(runState.finalDeliverySent, false);
+
+    await executeTool('send_message', {
+      platform: 'WHATSAPP',
+      to: '49123456789',
+      content: 'Finished result.',
+    }, context, engine);
+
+    assert.equal(sent.length, 2);
+    assert.equal(runState.messagingSent, true);
+    assert.equal(runState.explicitMessageSent, true);
+    assert.equal(runState.finalDeliverySent, true);
+    assert.deepEqual(runState.sentMessages, ['Finished result.']);
+  });
+
   test('task runtime start is idempotent and reports truthful state', async () => {
     const cronHarness = createCronHarness();
     runtime = new TaskRuntime(


### PR DESCRIPTION
## Summary

- **Heartbeat fix**: supervisor now injects steering after runtime heartbeats demanding the model use `send_interim_update` in its own words; removed `finalDeliverySent` early-exit that silenced supervisor after first send
- **Grace call**: replaced hard iteration-limit throw with a tool-less model call (Hermes pattern) so the model can still deliver a final answer; fixed fallthrough that threw after successful grace call
- **Judge LLM removed**: `decideLoopState()` and `evaluateTaskCompleteSignal()` deleted — loop exits when AI returns text with no tool calls or calls `task_complete` directly
- **Stagnation counter removed**: false positive rate ~62% for read-heavy tasks (summarize issues, find usages); removed entirely
- **Immediate first-error guidance**: EISDIR and `owner_repo` format errors now get corrective guidance on the very first failure (not after 3 repeats)
- **Research budget**: `execute`/`plan_execute` modes get a system message before the loop — after 3 read/list/search calls the agent must take a concrete action
- **Output fingerprint guard**: djb2 hash of list/search/get results; on duplicate response from any tool a `DUPLICATE DATA` steering message fires to prevent re-fetching the same data via different tool calls

## What this fixes

Production run `2be0046e` spent 29 iterations and 8 minutes reading GitHub issues 20 different ways, sent only hardcoded heartbeats, and never created the PR. All root causes addressed above.

## Test plan

- [x] `node --test test/backend/unit/agent_improvements.test.js` — 6/6 pass
- [x] `node --test test/backend/unit/messaging_progress_supervisor.test.js` — 21/21 pass
- [ ] Deploy and run a GitHub PR-creation task end-to-end